### PR TITLE
limit-text-buffer-size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "odbc-api"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "csv",
@@ -266,7 +266,7 @@ checksum = "c0c8c768ceb08f5b3738a01ac259f355ec22e0e9b248d31eb691ca3562b170a8"
 
 [[package]]
 name = "odbcsv"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 * `TextColumn` is now generic over its character type. The type alias `CharColumn` for
   `TextColumn<u8>` can serve as a drop in replacement for the previous iteration of `TextColumn`.
 * `AnyColumnBuffer` has a new variant called `WText` holding a UTF-16 `TextColumn<u16>` or `WCharColumn`.
+* `TextRowSet::for_cursor` has a new parameter `max_str_limit` to designate the upper limit for column buffer size.
+
 ## 0.17.0
 
 * Introduces `Cursor::next_row` to fetch data without binding buffers first.

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@
 * `TextColumn` is now generic over its character type. The type alias `CharColumn` for
   `TextColumn<u8>` can serve as a drop in replacement for the previous iteration of `TextColumn`.
 * `AnyColumnBuffer` has a new variant called `WText` holding a UTF-16 `TextColumn<u16>` or `WCharColumn`.
-* `TextRowSet::for_cursor` has a new parameter `max_str_limit` to designate the upper limit for column buffer size.
+* `TextRowSet::for_cursor` has a new parameter `max_str_len` to designate the upper limit for column buffer size.
 * Add `TextRowSet::indicator_at` to allow checking for truncation of strings.
 
 ## 0.17.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
   `TextColumn<u8>` can serve as a drop in replacement for the previous iteration of `TextColumn`.
 * `AnyColumnBuffer` has a new variant called `WText` holding a UTF-16 `TextColumn<u16>` or `WCharColumn`.
 * `TextRowSet::for_cursor` has a new parameter `max_str_limit` to designate the upper limit for column buffer size.
+* Add `TextRowSet::indicator_at` to allow checking for truncation of strings.
 
 ## 0.17.0
 

--- a/odbc-api/Cargo.toml
+++ b/odbc-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc-api"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Markus Klein <markus-klein@live.de>"]
 edition = "2018"
 license = "MIT"

--- a/odbc-api/src/buffers.rs
+++ b/odbc-api/src/buffers.rs
@@ -3,6 +3,7 @@ mod bin_column;
 mod column_with_indicator;
 mod columnar;
 mod description;
+mod indicator;
 mod text_column;
 mod text_row_set;
 
@@ -11,6 +12,7 @@ pub use self::{
     column_with_indicator::{OptIt, OptWriter},
     columnar::{AnyColumnView, AnyColumnViewMut, ColumnarRowSet},
     description::{BufferDescription, BufferKind},
+    indicator::Indicator,
     text_column::{CharColumn, TextColumn, TextColumnIt, TextColumnWriter, WCharColumn},
     text_row_set::TextRowSet,
 };

--- a/odbc-api/src/buffers/indicator.rs
+++ b/odbc-api/src/buffers/indicator.rs
@@ -1,0 +1,31 @@
+use std::convert::TryInto;
+
+use odbc_sys::{NO_TOTAL, NULL_DATA};
+
+/// Indicates existence and length of a value.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Indicator {
+    /// Field does not exist
+    Null,
+    /// Field exists, but its length had not be reported by the driver.
+    NoTotal,
+    /// Fields exists. Value indicates number of bytes required to store the value. In case of
+    /// truncated data, this is the untruncated true length.
+    Length(usize),
+}
+
+impl Indicator {
+    /// Creates an indicator from an `isize` indicator value returned by ODBC. Users of this crate
+    /// have likely no need to call this method.
+    pub fn from_isize(indicator: isize) -> Self {
+        match indicator {
+            NULL_DATA => Indicator::Null,
+            NO_TOTAL => Indicator::NoTotal,
+            other => Indicator::Length(
+                other
+                    .try_into()
+                    .expect("Length indicator must be non-negative."),
+            ),
+        }
+    }
+}

--- a/odbc-api/src/buffers/text_column.rs
+++ b/odbc-api/src/buffers/text_column.rs
@@ -142,8 +142,7 @@ impl<C> TextColumn<C> {
                     new_value[..max_copy_length].clone_from_slice(&old_value[..max_copy_length]);
                 }
                 Indicator::Length(num_bytes_len) => {
-                    let num_bytes_to_copy =
-                        min(num_bytes_len / size_of::<C>(), max_copy_length);
+                    let num_bytes_to_copy = min(num_bytes_len / size_of::<C>(), max_copy_length);
                     new_value[..num_bytes_to_copy].copy_from_slice(&old_value[..num_bytes_to_copy]);
                 }
             }

--- a/odbc-api/src/buffers/text_row_set.rs
+++ b/odbc-api/src/buffers/text_row_set.rs
@@ -1,4 +1,4 @@
-use super::{Indicator, text_column::TextColumn};
+use super::{text_column::TextColumn, Indicator};
 use crate::{handles::Statement, Cursor, Error, ParameterCollection, RowSetBuffer};
 use std::{
     cmp::min,
@@ -109,7 +109,7 @@ impl TextRowSet {
     pub fn for_cursor(
         batch_size: u32,
         cursor: &impl Cursor,
-        max_str_limit: Option<usize>,
+        max_str_len: Option<usize>,
     ) -> Result<TextRowSet, Error> {
         let num_cols = cursor.num_result_cols()?;
         let buffers = (1..(num_cols + 1))
@@ -122,7 +122,7 @@ impl TextRowSet {
                         cursor.col_display_size(col_index as u16)? as usize
                     };
                 // Apply upper bound if specified
-                let max_str_len = max_str_limit
+                let max_str_len = max_str_len
                     .map(|limit| min(limit, reported_len))
                     .unwrap_or(reported_len);
                 Ok(TextColumn::new(batch_size as usize, max_str_len))

--- a/odbc-api/src/guide.rs
+++ b/odbc-api/src/guide.rs
@@ -60,8 +60,8 @@
 //!             writer.write_record(headline)?;
 //!
 //!             // Use schema in cursor to initialize a text buffer large enough to hold the largest
-//!             // possible strings for each column.
-//!             let mut buffers = TextRowSet::for_cursor(BATCH_SIZE, &cursor)?;
+//!             // possible strings for each column up to an upper limit of 4KiB.
+//!             let mut buffers = TextRowSet::for_cursor(BATCH_SIZE, &cursor, Some(4096))?;
 //!             // Bind the buffer to the cursor. It is now being filled with every call to fetch.
 //!             let mut row_set_cursor = cursor.bind_buffer(&mut buffers)?;
 //!

--- a/odbc-api/tests/common.rs
+++ b/odbc-api/tests/common.rs
@@ -38,7 +38,7 @@ pub fn setup_empty_table(
 
 pub fn cursor_to_string(cursor: impl Cursor) -> String {
     let batch_size = 20;
-    let mut buffer = buffers::TextRowSet::for_cursor(batch_size, &cursor).unwrap();
+    let mut buffer = buffers::TextRowSet::for_cursor(batch_size, &cursor, None).unwrap();
     let mut row_set_cursor = cursor.bind_buffer(&mut buffer).unwrap();
 
     let mut text = String::new();

--- a/odbc-api/tests/integration.rs
+++ b/odbc-api/tests/integration.rs
@@ -4,7 +4,14 @@ use test_case::test_case;
 
 use common::{cursor_to_string, setup_empty_table, SingleColumnRowSetBuffer, ENV};
 
-use odbc_api::{ColumnDescription, Cursor, DataType, IntoParameter, Nullability, Nullable, U16String, buffers::{AnyColumnView, AnyColumnViewMut, BufferDescription, BufferKind, ColumnarRowSet, Indicator, TextRowSet}, parameter::VarChar32};
+use odbc_api::{
+    buffers::{
+        AnyColumnView, AnyColumnViewMut, BufferDescription, BufferKind, ColumnarRowSet, Indicator,
+        TextRowSet,
+    },
+    parameter::VarChar32,
+    ColumnDescription, Cursor, DataType, IntoParameter, Nullability, Nullable, U16String,
+};
 use std::{iter, thread};
 
 const MSSQL: &str =

--- a/odbc-api/tests/integration.rs
+++ b/odbc-api/tests/integration.rs
@@ -4,13 +4,7 @@ use test_case::test_case;
 
 use common::{cursor_to_string, setup_empty_table, SingleColumnRowSetBuffer, ENV};
 
-use odbc_api::{
-    buffers::{
-        AnyColumnView, AnyColumnViewMut, BufferDescription, BufferKind, ColumnarRowSet, TextRowSet,
-    },
-    parameter::VarChar32,
-    ColumnDescription, Cursor, DataType, IntoParameter, Nullability, Nullable, U16String,
-};
+use odbc_api::{ColumnDescription, Cursor, DataType, IntoParameter, Nullability, Nullable, U16String, buffers::{AnyColumnView, AnyColumnViewMut, BufferDescription, BufferKind, ColumnarRowSet, Indicator, TextRowSet}, parameter::VarChar32};
 use std::{iter, thread};
 
 const MSSQL: &str =
@@ -1364,6 +1358,10 @@ fn capped_text_buffer(connection_string: &str) {
     let field = batch.at_as_str(0, 0).unwrap().unwrap();
     // Only 'Hello' from 'Hello, World!' remains due to upper limit.
     assert_eq!("Hello", field);
+    // Indicator reports actual length of the field on the database.
+    assert_eq!(Indicator::Length(13), batch.indicator_at(0, 0));
+    // Assert that maximum length is reported correctly.
+    assert_eq!(5, batch.max_len(0));
 }
 
 /// This test is inspired by a bug caused from a fetch statement generating a lot of diagnostic

--- a/odbcsv/Cargo.toml
+++ b/odbcsv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbcsv"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Markus Klein <markus-klein@live.de>"]
 edition = "2018"
 license = "MIT"
@@ -29,7 +29,7 @@ readme = "Readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-odbc-api = { version = "0.17.0", path = "../odbc-api" }
+odbc-api = { version = "0.18.0", path = "../odbc-api" }
 csv = "1.1.5"
 anyhow = "1.0.38"
 stderrlog = "0.5.1"

--- a/odbcsv/Changelog.md
+++ b/odbcsv/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.15
+
+* New optional parameter `max-str-len` can be used to limit memory consumption.
+
 ## 0.3.14
 
 * Insert now logs batch number and rows

--- a/odbcsv/src/main.rs
+++ b/odbcsv/src/main.rs
@@ -214,7 +214,7 @@ fn query(environment: &Environment, opt: &QueryOpt) -> Result<(), Error> {
             let headline: Vec<String> = cursor.column_names()?.collect::<Result<_, _>>()?;
             writer.write_record(headline)?;
 
-            let mut buffers = TextRowSet::for_cursor(*batch_size, &cursor)?;
+            let mut buffers = TextRowSet::for_cursor(*batch_size, &cursor, None)?;
             let mut row_set_cursor = cursor.bind_buffer(&mut buffers)?;
 
             // Use this number to count the batches. Only used for logging.

--- a/odbcsv/tests/lib.rs
+++ b/odbcsv/tests/lib.rs
@@ -90,6 +90,30 @@ fn query_mssql() {
 }
 
 #[test]
+fn max_str_len() {
+    let csv = "title,year\n\
+        Jura,1993\n\
+        2001,1968\n\
+        Inte,\n\
+    ";
+
+    Command::cargo_bin("odbcsv")
+        .unwrap()
+        .args(&[
+            "-vvvv",
+            "query",
+            "--max-str-len",
+            "4",
+            "--connection-string",
+            MSSQL,
+            "SELECT title, year from Movies",
+        ])
+        .assert()
+        .success()
+        .stdout(csv);
+}
+
+#[test]
 fn placeholders() {
     let csv = "title\n\
         2001: A Space Odyssey\n\


### PR DESCRIPTION
Convinience for limiting text buffer size, and getter functions to enable detection of truncation.

Inspired by #41