### PR TITLE
Normalize line endings in MSSQL Dockerfile

### DIFF
--- a/docker/mssql/Dockerfile
+++ b/docker/mssql/Dockerfile
@@ -1,8 +1,16 @@
 FROM mcr.microsoft.com/mssql/server:2019-CU5-ubuntu-18.04
 
+USER root
+
 COPY ./setup.sql .
 COPY ./import-data.sh .
 COPY ./entrypoint.sh .
+
+# Normalize line endings if they've been modified locally (e.g. git checkout on Windows)
+RUN apt-get update
+RUN apt-get install -y dos2unix
+RUN dos2unix ./import-data.sh
+RUN dos2unix ./entrypoint.sh
 
 # Switch back to mssql user and run the entrypoint script
 USER mssql


### PR DESCRIPTION
Either git or Docker (I'm not sure which) added `\r` into the line endings for `./import-data.sh`. So when I tried to run `docker-compose up` the tables weren't populated fully, so some tests would fail.

We could work around this using the `dos2unix` package or similar.