### PR TITLE
Add `connect_with_complete_prompt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "lazy_static",
  "log",
  "odbc-sys",
+ "raw-window-handle",
  "test-case",
  "thiserror",
  "widestring",
@@ -344,6 +345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a441a7a6c80ad6473bd4b74ec1c9a4c951794285bf941c2126f607c72e48211"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/odbc-api/Cargo.toml
+++ b/odbc-api/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = "1.0.24"
 log = "0.4.14"
 widestring = "0.4.3"
 force-send-sync = "1.0.0"
+raw-window-handle = "0.3"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/odbc-api/src/environment.rs
+++ b/odbc-api/src/environment.rs
@@ -177,27 +177,20 @@ impl Environment {
     /// If the connection is successful, the complete connection string (including any information
     /// provided by the user through a prompt) is returned.
     ///
-    /// # Arguments
+    /// # Parameters
     ///
-    /// * `connection_string` - Connection string.
-    /// * `window` - A parent window handle to use for any prompts. If the window handle is
+    /// * `connection_string`: Connection string.
+    /// * `window`: A parent window handle to use for any prompts. If the window handle is
     ///   invalid or unsupported on the current platform, the prompt won't be displayed and `Error`
     ///   will be returned.
-    /// * `max_complete_connection_string_len` - The maximum allowed length for the returned
+    /// * `max_complete_connection_string_len`: The maximum allowed length for the returned
     ///   complete connection string. This is recommended to be at least 1024. If the complete
     ///   connection string is longer than this length, `Error` will be returned.
     ///
     /// # Example
     ///
     /// ```no_run
-    /// # if cfg!(target_os = "windows") {
-    /// # struct Window;
-    /// # unsafe impl raw_window_handle::HasRawWindowHandle for Window {
-    /// #     fn raw_window_handle(&self) -> raw_window_handle::RawWindowHandle {
-    /// #         raw_window_handle::RawWindowHandle::Windows(raw_window_handle::windows::WindowsHandle::empty())
-    /// #     }
-    /// # }
-    /// # let window = Window;
+    /// # fn f(window: impl raw_window_handle::HasRawWindowHandle) -> Result<(), odbc_api::Error> {
     /// // I hereby solemnly swear that this is the only ODBC environment in the entire process,
     /// // thus making this call safe.
     /// let env = unsafe {
@@ -232,8 +225,7 @@ impl Environment {
     ///
     /// // Now `connection_string` might be something like
     /// // `DSN=MicrosoftAccessFile;DBQ=C:\Db\Example.accdb;DriverId=25;FIL=MS Access;MaxBufferSize=2048;`
-    /// # }
-    /// # Ok::<(), odbc_api::Error>(())
+    /// # Ok(()) }
     /// ```
     pub fn connect_with_complete_prompt(
         &self,

--- a/odbc-api/src/handles/connection.rs
+++ b/odbc-api/src/handles/connection.rs
@@ -9,7 +9,11 @@ use odbc_sys::{
 };
 use std::{convert::TryInto, marker::PhantomData, ptr::null_mut};
 use widestring::{U16Str, U16CStr};
-use raw_window_handle::{RawWindowHandle, HasRawWindowHandle};
+use raw_window_handle::HasRawWindowHandle;
+
+// Currently only windows driver manager supports prompt.
+#[cfg(target_os="windows")]
+use raw_window_handle::RawWindowHandle;
 
 /// The connection handle references storage of all information about the connection to the data
 /// source, including status, transaction state, and error information.

--- a/odbc-api/src/handles/error.rs
+++ b/odbc-api/src/handles/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     /// SQL Error had been returned by a low level ODBC function call. A Diagnostic record is
     /// obtained and associated with this error.
     Diagnostics(DiagnosticRecord),
+    #[error("No data was returned.")]
+    NoData,
 }
 
 pub trait IntoResult {
@@ -40,6 +42,7 @@ impl IntoResult for SqlReturn {
                     Err(Error::NoDiagnostics)
                 }
             }
+            SqlReturn::NO_DATA => Err(Error::NoData),
             r => panic!("Unexpected odbc function result: {:?}", r),
         }
     }


### PR DESCRIPTION
Fixes #54

This uses the approach we discussed in #54.

Let me know if we'd like to handle `Error` some other way, or we need to add the window example somewhere, or any other changes you'd like.