### PR TITLE
Add `database_management_system_name`

### DIFF
--- a/odbc-api/src/connection.rs
+++ b/odbc-api/src/connection.rs
@@ -1,4 +1,9 @@
-use crate::{CursorImpl, Error, Preallocated, Prepared, execute::execute_with_parameters, handles::{self, State, Statement, StatementImpl}, parameter_collection::ParameterCollection};
+use crate::{
+    execute::execute_with_parameters,
+    handles::{self, State, Statement, StatementImpl},
+    parameter_collection::ParameterCollection,
+    CursorImpl, Error, Preallocated, Prepared,
+};
 use std::{borrow::Cow, thread::panicking};
 use widestring::{U16Str, U16String};
 
@@ -239,6 +244,20 @@ impl<'c> Connection<'c> {
     /// See: <https://stackoverflow.com/questions/4207458/using-unixodbc-in-a-multithreaded-concurrent-setting>
     pub unsafe fn promote_to_send(self) -> force_send_sync::Send<Self> {
         force_send_sync::Send::new(self)
+    }
+
+    /// Fetch the name of the database management system used by the connection and store it into
+    /// the provided `buf`.
+    pub fn fetch_database_management_system_name(&self, buf: &mut Vec<u16>) -> Result<(), Error> {
+        self.connection.fetch_database_management_system_name(buf)
+    }
+
+    /// Get the name of the database management system used by the connection.
+    pub fn database_management_system_name(&self) -> Result<String, Error> {
+        let mut buf = Vec::new();
+        self.fetch_database_management_system_name(&mut buf)?;
+        let name = U16String::from_vec(buf);
+        Ok(name.to_string().unwrap())
     }
 }
 

--- a/odbc-api/tests/integration.rs
+++ b/odbc-api/tests/integration.rs
@@ -2519,3 +2519,14 @@ fn many_diagnostic_messages() {
 
     // We do not have an explicit assertion, we are just happy if no integer addition overflows.
 }
+
+#[test_case(MSSQL, "Microsoft SQL Server"; "Microsoft SQL Server")]
+#[test_case(MARIADB, "MariaDB"; "Maria DB")]
+#[test_case(SQLITE_3, "SQLite"; "SQLite 3")]
+fn database_management_system_name(profile: &Profile, expected_name: &'static str) {
+    let conn = ENV
+        .connect_with_connection_string(profile.connection_string)
+        .unwrap();
+    let actual_name = conn.database_management_system_name().unwrap();
+    assert_eq!(expected_name, actual_name);
+}


### PR DESCRIPTION
It's useful to be able to know the name of the DBMS used by the connection. This allows us to determine which DBMS is being used in order to use provider-specific syntax, scalar functions, etc.

For example, multiple ODBC drivers might connect to SQL Server, but trying to write a heuristic to check the driver name or driver filename could be error-prone or complicated. Instead by using the DBMS name, we should be able to more reliably detect which DBMS is being used (regardless of which driver is being used to connect to it). Three of the SQL Server drivers I have installed return `Microsoft SQL Server` as the DBMS name, and two Access drivers return `ACCESS`.