### PR TITLE
Expose max catalog, schema, table, column name lengths

### DIFF
--- a/odbc-api/src/connection.rs
+++ b/odbc-api/src/connection.rs
@@ -259,6 +259,26 @@ impl<'c> Connection<'c> {
         let name = U16String::from_vec(buf);
         Ok(name.to_string().unwrap())
     }
+
+    /// Maximum length of catalog names in bytes.
+    pub fn max_catalog_name_len(&self) -> Result<usize, Error> {
+        self.connection.max_catalog_name_len().map(|v| v as usize)
+    }
+
+    /// Maximum length of schema names in bytes.
+    pub fn max_schema_name_len(&self) -> Result<usize, Error> {
+        self.connection.max_schema_name_len().map(|v| v as usize)
+    }
+
+    /// Maximum length of table names in bytes.
+    pub fn max_table_name_len(&self) -> Result<usize, Error> {
+        self.connection.max_table_name_len().map(|v| v as usize)
+    }
+
+    /// Maximum length of column names in bytes.
+    pub fn max_column_name_len(&self) -> Result<usize, Error> {
+        self.connection.max_column_name_len().map(|v| v as usize)
+    }
 }
 
 /// You can use this method to escape a password so it is suitable to be appended to an ODBC

--- a/odbc-api/src/handles/connection.rs
+++ b/odbc-api/src/handles/connection.rs
@@ -223,4 +223,39 @@ impl<'c> Connection<'c> {
 
         Ok(())
     }
+
+    fn get_info_u16(&self, info_type: InfoType) -> Result<u16, Error> {
+        unsafe {
+            let mut value = 0u16;
+            SQLGetInfoW(
+                self.handle,
+                info_type,
+                &mut value as *mut u16 as Pointer,
+                0,
+                null_mut(),
+            )
+            .into_result(self)?;
+            Ok(value)
+        }
+    }
+
+    /// Maximum length of catalog names in bytes.
+    pub fn max_catalog_name_len(&self) -> Result<u16, Error> {
+        self.get_info_u16(InfoType::MaxCatalogNameLen)
+    }
+
+    /// Maximum length of schema names in bytes.
+    pub fn max_schema_name_len(&self) -> Result<u16, Error> {
+        self.get_info_u16(InfoType::MaxSchemaNameLen)
+    }
+
+    /// Maximum length of table names in bytes.
+    pub fn max_table_name_len(&self) -> Result<u16, Error> {
+        self.get_info_u16(InfoType::MaxTableNameLen)
+    }
+
+    /// Maximum length of column names in bytes.
+    pub fn max_column_name_len(&self) -> Result<u16, Error> {
+        self.get_info_u16(InfoType::MaxColumnNameLen)
+    }
 }

--- a/odbc-api/tests/integration.rs
+++ b/odbc-api/tests/integration.rs
@@ -2476,7 +2476,10 @@ fn get_full_connection_string_truncated(profile: &Profile) {
     )
     .unwrap();
 
-    eprintln!("Output connection string: {}", completed_connection_string.to_utf8());
+    eprintln!(
+        "Output connection string: {}",
+        completed_connection_string.to_utf8()
+    );
 
     assert!(completed_connection_string.is_truncated());
 }
@@ -2529,4 +2532,37 @@ fn database_management_system_name(profile: &Profile, expected_name: &'static st
         .unwrap();
     let actual_name = conn.database_management_system_name().unwrap();
     assert_eq!(expected_name, actual_name);
+}
+
+// Check the max name length for the catalogs, schemas, tables, and columns.
+#[test_case(MSSQL, 128, 128, 128, 128; "Microsoft SQL Server")]
+#[test_case(MARIADB, 256, 0, 256, 255; "Maria DB")]
+#[test_case(SQLITE_3, 255, 255, 255, 255; "SQLite 3")]
+fn name_limits(
+    profile: &Profile,
+    expected_max_catalog_name_len: usize,
+    expected_max_schema_name_len: usize,
+    expected_max_table_name_len: usize,
+    expected_max_column_name_len: usize,
+) {
+    let conn = ENV
+        .connect_with_connection_string(profile.connection_string)
+        .unwrap();
+
+    assert_eq!(
+        conn.max_catalog_name_len().unwrap(),
+        expected_max_catalog_name_len
+    );
+    assert_eq!(
+        conn.max_schema_name_len().unwrap(),
+        expected_max_schema_name_len
+    );
+    assert_eq!(
+        conn.max_table_name_len().unwrap(),
+        expected_max_table_name_len
+    );
+    assert_eq!(
+        conn.max_column_name_len().unwrap(),
+        expected_max_column_name_len
+    );
 }


### PR DESCRIPTION
I'd like to be able to query metadata about tables and columns before making queries that attempt to use them, so I can determine whether tables are missing, columns are missing, columns have an unexpected type, etc. ahead of time. It's already mostly possible to do this today by using data source-specific schema queries or use `describe_col` on empty record sets (e.g. `SELECT * WHERE 0=1`), but I'd prefer to use the full set of metadata from [`SQLTables`](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqltables-function?view=sql-server-ver15) and [`SQLColumns`](https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcolumns-function?view=sql-server-2017) instead.

This PR adds some of the max name lengths needed to eventually be able to use `SQLColumns` as mentioned under the `SQLColumns` documentation comments (basically just the appropriate sizes to use for `VARCHAR`):
> The lengths of VARCHAR columns are not shown in the table; the actual lengths depend on the data source. To determine the actual lengths of the TABLE_CAT, TABLE_SCHEM, TABLE_NAME, and COLUMN_NAME columns, an application can call SQLGetInfo with the SQL_MAX_CATALOG_NAME_LEN, SQL_MAX_SCHEMA_NAME_LEN, SQL_MAX_TABLE_NAME_LEN, and SQL_MAX_COLUMN_NAME_LEN options.

Technically we could keep these private for internal use for now, but I thought it might be useful to expose them.