### PR TITLE
Add `current_catalog`

### DIFF
--- a/odbc-api/src/connection.rs
+++ b/odbc-api/src/connection.rs
@@ -279,6 +279,20 @@ impl<'c> Connection<'c> {
     pub fn max_column_name_len(&self) -> Result<usize, Error> {
         self.connection.max_column_name_len().map(|v| v as usize)
     }
+
+    /// Fetch the name of the current catalog being used by the connection and store it into the
+    /// provided `buf`.
+    pub fn fetch_current_catalog(&self, buf: &mut Vec<u16>) -> Result<(), Error> {
+        self.connection.fetch_current_catalog(buf)
+    }
+
+    /// Get the name of the current catalog being used by the connection.
+    pub fn current_catalog(&self) -> Result<String, Error> {
+        let mut buf = Vec::new();
+        self.fetch_current_catalog(&mut buf)?;
+        let name = U16String::from_vec(buf);
+        Ok(name.to_string().unwrap())
+    }
 }
 
 /// You can use this method to escape a password so it is suitable to be appended to an ODBC

--- a/odbc-api/src/handles/buffer.rs
+++ b/odbc-api/src/handles/buffer.rs
@@ -6,9 +6,14 @@ use std::{
 
 use widestring::U16CStr;
 
-/// Clamps a usize between `0` and `SmallInt::MAX`.
+/// Clamps a usize between `0` and `i16::MAX`.
 pub fn clamp_small_int(n: usize) -> i16 {
     min(n, i16::MAX as usize) as i16
+}
+
+/// Clamps a usize between `0` and `i32::MAX`.
+pub fn clamp_int(n: usize) -> i32 {
+    min(n, i32::MAX as usize) as i32
 }
 
 /// Returns a pointer suitable to be passed as an output buffer to ODBC functions. Most notably it

--- a/odbc-api/tests/integration.rs
+++ b/odbc-api/tests/integration.rs
@@ -2566,3 +2566,15 @@ fn name_limits(
         expected_max_column_name_len
     );
 }
+
+// Check the current catalog being used by the connection.
+#[test_case(MSSQL, "master"; "Microsoft SQL Server")]
+#[test_case(MARIADB, "test_db"; "Maria DB")]
+#[test_case(SQLITE_3, ""; "SQLite 3")]
+fn current_catalog(profile: &Profile, expected_catalog: &str) {
+    let conn = ENV
+        .connect_with_connection_string(profile.connection_string)
+        .unwrap();
+
+    assert_eq!(conn.current_catalog().unwrap(), expected_catalog);
+}


### PR DESCRIPTION
Following the same pattern as #71, these functions get the name of the current catalog being used by the connection.

The catalog can be switched while a connection is open (e.g. switching between databases with `USE` in SQL Server) so this just returns whichever catalog is currently being used.

This is useful when combined with catalog queries (e.g. #73) because we can query columns from the current catalog.