### PR TITLE
Add `columns` query and buffer descriptions

### DIFF
--- a/odbc-api/src/execute.rs
+++ b/odbc-api/src/execute.rs
@@ -54,3 +54,27 @@ where
         }
     }
 }
+
+/// Shared implementation for executing a columns query between [`Connection`] and
+/// [`Preallocated`].
+pub fn columns<'o, S>(
+    mut statement: S,
+    catalog_name: &U16Str,
+    schema_name: &U16Str,
+    table_name: &U16Str,
+    column_name: &U16Str,
+) -> Result<Option<CursorImpl<'o, S>>, Error>
+where
+    S: BorrowMut<StatementImpl<'o>>,
+{
+    let stmt = statement.borrow_mut();
+
+    stmt.columns(catalog_name, schema_name, table_name, column_name)?;
+
+    // Check if a result set has been created.
+    if stmt.num_result_cols()? == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(CursorImpl::new(statement)))
+    }
+}

--- a/odbc-api/src/handles.rs
+++ b/odbc-api/src/handles.rs
@@ -24,7 +24,7 @@ pub use {
     column_description::{ColumnDescription, Nullability},
     connection::Connection,
     data_type::DataType,
-    diagnostics::{State, Record},
+    diagnostics::{Record, State},
     environment::Environment,
     error::Error,
     statement::{ParameterDescription, Statement, StatementImpl},

--- a/odbc-api/src/preallocated.rs
+++ b/odbc-api/src/preallocated.rs
@@ -1,8 +1,9 @@
 use widestring::{U16Str, U16String};
 
 use crate::{
-    execute::execute_with_parameters, handles::StatementImpl, CursorImpl, Error,
-    ParameterCollection,
+    execute::{columns, execute_with_parameters},
+    handles::StatementImpl,
+    CursorImpl, Error, ParameterCollection,
 };
 
 /// A preallocated SQL statement handle intended for sequential execution of different queries. See
@@ -98,7 +99,7 @@ impl<'o> Preallocated<'o> {
         self.execute_utf16(&query, params)
     }
 
-    /// Transfer ownership to the underlying statemet handle.
+    /// Transfer ownership to the underlying statement handle.
     ///
     /// The resulting type is one level of indirection away from the raw pointer of the ODBC API. It
     /// no longer has any guarantees about bound buffers, but is still guaranteed to be a valid
@@ -108,5 +109,23 @@ impl<'o> Preallocated<'o> {
     /// accessible through safe abstractions.
     pub fn into_statement(self) -> StatementImpl<'o> {
         self.statement
+    }
+
+    /// Query all columns that match the provided catalog name, schema pattern, table pattern, and
+    /// column pattern.
+    pub fn columns(
+        &mut self,
+        catalog_name: &str,
+        schema_name: &str,
+        table_name: &str,
+        column_name: &str,
+    ) -> Result<Option<CursorImpl<'o, &mut StatementImpl<'o>>>, Error> {
+        columns(
+            &mut self.statement,
+            &U16String::from_str(catalog_name),
+            &U16String::from_str(schema_name),
+            &U16String::from_str(table_name),
+            &U16String::from_str(column_name),
+        )
     }
 }


### PR DESCRIPTION
Based on the ideas mentioned in https://github.com/pacman82/odbc-api/pull/73#issuecomment-858403648, I tried to split off some of the lower level functions for `columns` and `columns_buffer_description`. Please let me know if this makes sense or if we need to change the approach somehow.