### PR TITLE
Expose buffers in views

### DIFF
--- a/odbc-api/src/buffers/bin_column.rs
+++ b/odbc-api/src/buffers/bin_column.rs
@@ -220,14 +220,40 @@ pub struct BinColumnIt<'c> {
 }
 
 impl<'c> BinColumnIt<'c> {
+    /// The maximum length (in bytes) of an individual item of this iterator.
+    pub fn max_len(&self) -> usize {
+        self.col.max_len()
+    }
+
     /// Returns the values buffer of this [`BinColumnIt`].
+    ///
+    /// The values in this slice are only determined for specified slices.
+    /// Specifically, row `index` is the slice `[offset..offset + lengths[index]]`
+    /// of this slice, where
+    /// * `offset = index * self.max_len();`
+    /// * `lengths = self.lengths()`
+    ///
+    /// In other words, this slice has a fix spacing given by `max_len`, and the number of
+    /// valid items in each space is given by `self.lengths()[index]`.
+    ///
+    /// Note that there is no guarantee that `offset + lengths[index]` is smaller than
+    /// this slice's length; i.e. _do_ perform boundary checks.
+    ///
+    /// `max_len`, `lengths` and this function can be used to reconstruct the individual
+    /// slices.
     pub fn values(&self) -> &[u8] {
         &self.col.values
     }
 
-    /// Returns the indicators buffer of this [`BinColumnIt`].
-    pub fn indicators(&self) -> &[isize] {
-        &self.col.indicators
+    /// Returns the lengths of this [`BinColumnIt`].
+    ///
+    /// This slice is guaranteed to have a length equal to the number of rows of this view.
+    ///
+    /// A value in this slice is:
+    /// * `-1` when the row is null
+    /// * a positive number denoting the rows' length in all other cases.
+    pub fn lengths(&self) -> &[isize] {
+        &self.col.indicators[..self.num_rows]
     }
 }
 

--- a/odbc-api/src/buffers/bin_column.rs
+++ b/odbc-api/src/buffers/bin_column.rs
@@ -251,6 +251,7 @@ impl<'c> BinColumnIt<'c> {
     ///
     /// A value in this slice is:
     /// * `-1` when the row is null
+    /// * `-4` when the length is unknown, meaning that the buffer is too small to hold all the data from the row
     /// * a positive number denoting the rows' length in all other cases.
     pub fn lengths(&self) -> &[isize] {
         &self.col.indicators[..self.num_rows]

--- a/odbc-api/src/buffers/bin_column.rs
+++ b/odbc-api/src/buffers/bin_column.rs
@@ -219,6 +219,18 @@ pub struct BinColumnIt<'c> {
     col: &'c BinColumn,
 }
 
+impl<'c> BinColumnIt<'c> {
+    /// Returns the values buffer of this [`BinColumnIt`].
+    pub fn values(&self) -> &[u8] {
+        &self.col.values
+    }
+
+    /// Returns the indicators buffer of this [`BinColumnIt`].
+    pub fn indicators(&self) -> &[isize] {
+        &self.col.indicators
+    }
+}
+
 impl<'c> Iterator for BinColumnIt<'c> {
     type Item = Option<&'c [u8]>;
 

--- a/odbc-api/src/buffers/column_with_indicator.rs
+++ b/odbc-api/src/buffers/column_with_indicator.rs
@@ -235,4 +235,20 @@ impl<'a, T> NullableSliceMut<'a, T> {
             }
         }
     }
+
+    /// Returns the values of this [`NullableSliceMut`].
+    /// This slice is guaranteed to have a length equal to the number of rows of this view.
+    ///
+    /// ODBC drivers will only read values whose corresponding indicator is different from -1.
+    pub fn values(&mut self) -> &mut [T] {
+        self.values
+    }
+
+    /// Returns the indicators of this [`NullableSliceMut`].
+    /// This slice is guaranteed to have a length equal to the number of rows of this view.
+    ///
+    /// Write `-1` to it to indicate a null row, and anything else to indicate a valid row
+    pub fn indicators(&mut self) -> &mut [isize] {
+        self.indicators
+    }
 }

--- a/odbc-api/src/buffers/column_with_indicator.rs
+++ b/odbc-api/src/buffers/column_with_indicator.rs
@@ -94,12 +94,22 @@ impl<'a, T> NullableSlice<'a, T> {
         self.values.len()
     }
 
-    /// Returns the values buffer of this [`NullableSlice`].
+    /// Returns the values of this [`NullableSlice`].
+    /// This slice is guaranteed to have a length equal to the number of rows of this view.
+    ///
+    /// Item `index` of this slice is only determined for indexes whose row is not null
+    /// (see `indicators`).
     pub fn values(&self) -> &[T] {
         self.values
     }
 
-    /// Returns the indicators buffer of this [`NullableSlice`].
+    /// Returns the indicators of this [`NullableSlice`].
+    ///
+    /// This slice is guaranteed to have a length equal to the number of rows of this view.
+    ///
+    /// A value in this slice is:
+    /// * `-1` when the row is null
+    /// * any other number corresponds to a valid row
     pub fn indicators(&self) -> &[isize] {
         self.indicators
     }

--- a/odbc-api/src/buffers/column_with_indicator.rs
+++ b/odbc-api/src/buffers/column_with_indicator.rs
@@ -93,6 +93,16 @@ impl<'a, T> NullableSlice<'a, T> {
     pub fn len(&self) -> usize {
         self.values.len()
     }
+
+    /// Returns the values buffer of this [`NullableSlice`].
+    pub fn values(&self) -> &[T] {
+        self.values
+    }
+
+    /// Returns the indicators buffer of this [`NullableSlice`].
+    pub fn indicators(&self) -> &[isize] {
+        self.indicators
+    }
 }
 
 impl<'a, T> Iterator for NullableSlice<'a, T> {

--- a/odbc-api/src/buffers/text_column.rs
+++ b/odbc-api/src/buffers/text_column.rs
@@ -356,6 +356,44 @@ impl<'c, C> TextColumnIt<'c, C> {
             ret
         }
     }
+
+    /// The maximum length (in bytes) of an individual item of this iterator.
+    pub fn max_len(&self) -> usize {
+        self.col.max_len()
+    }
+
+    /// Returns the values buffer of this [`TextColumnIt`].
+    ///
+    /// The values in this slice are only determined for specified slices.
+    /// Specifically, row `index` is the slice `[offset..offset + lengths[index]]`
+    /// of this slice, where
+    /// * `offset = index * self.max_len();`
+    /// * `lengths = self.lengths()`
+    ///
+    /// In other words, this slice has a fix spacing given by `max_len`, and the number of
+    /// valid items in each space is given by `self.lengths()[index]`.
+    ///
+    /// Note that there is no guarantee that `offset + lengths[index]` is smaller than
+    /// this slice's length; i.e. _do_ perform boundary checks.
+    /// Furthermore, valid slices are not necessarily valid utf8.
+    ///
+    /// `max_len`, `lengths` and this function can be used to reconstruct the individual
+    /// slices.
+    pub fn values(&self) -> &[C] {
+        &self.col.values
+    }
+
+    /// Returns the lengths of this [`TextColumnIt`].
+    ///
+    /// This slice is guaranteed to have a length equal to the number of rows of this view.
+    ///
+    /// A value in this slice is:
+    /// * `-1` when the row is null
+    /// * `-4` when the length is unknown, meaning that the buffer is too small to hold all the data from the row
+    /// * a positive number denoting the rows' length in all other cases.
+    pub fn lengths(&self) -> &[isize] {
+        &self.col.indicators[..self.num_rows]
+    }
 }
 
 impl<'c> Iterator for TextColumnIt<'c, u8> {

--- a/odbc-api/tests/integration.rs
+++ b/odbc-api/tests/integration.rs
@@ -570,10 +570,15 @@ fn columnar_fetch_varbinary(profile: &Profile) {
     } else {
         panic!("Column View expected to be binary")
     };
+
     assert_eq!(Some(&b"Hello"[..]), col_it.next().unwrap());
     assert_eq!(Some(&b"World"[..]), col_it.next().unwrap());
     assert_eq!(Some(None), col_it.next()); // Expecting NULL
     assert_eq!(None, col_it.next()); // Expecting iterator end.
+
+    assert_eq!(&col_it.values()[0..5], b"Hello");
+    assert_eq!(&col_it.values()[10..10 + 5], b"World"); // 10 due to Varbinary(10)
+    assert_eq!(col_it.lengths(), &[5, 5]);
 }
 
 /// Bind a columnar buffer to a BINARY(5) column and fetch data.
@@ -667,44 +672,44 @@ fn columnar_fetch_timestamp(profile: &Profile) {
     } else {
         panic!("Column View expected to be binary")
     };
-    assert_eq!(
-        Some(&Timestamp {
-            year: 2021,
-            month: 3,
-            day: 20,
-            hour: 15,
-            minute: 24,
-            second: 12,
-            fraction: 120_000_000,
-        }),
-        col_it.next().unwrap()
-    );
-    assert_eq!(
-        Some(&Timestamp {
-            year: 2020,
-            month: 3,
-            day: 20,
-            hour: 15,
-            minute: 24,
-            second: 12,
-            fraction: 0,
-        }),
-        col_it.next().unwrap()
-    );
-    assert_eq!(
-        Some(&Timestamp {
-            year: 1970,
-            month: 1,
-            day: 1,
-            hour: 0,
-            minute: 0,
-            second: 0,
-            fraction: 0,
-        }),
-        col_it.next().unwrap()
-    );
+
+    let v1 = Timestamp {
+        year: 2021,
+        month: 3,
+        day: 20,
+        hour: 15,
+        minute: 24,
+        second: 12,
+        fraction: 120_000_000,
+    };
+
+    let v2 = Timestamp {
+        year: 2020,
+        month: 3,
+        day: 20,
+        hour: 15,
+        minute: 24,
+        second: 12,
+        fraction: 0,
+    };
+
+    let v3 = Timestamp {
+        year: 1970,
+        month: 1,
+        day: 1,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        fraction: 0,
+    };
+
+    assert_eq!(Some(&v1), col_it.next().unwrap());
+    assert_eq!(Some(&v2), col_it.next().unwrap());
+    assert_eq!(Some(&v3), col_it.next().unwrap());
     assert_eq!(Some(None), col_it.next()); // Expecting NULL
     assert_eq!(None, col_it.next()); // Expecting iterator end.
+
+    assert_eq!(&col_it.values()[..3], &[v1, v2, v3])
 }
 
 /// Insert values into a DATETIME2 column using a columnar buffer

--- a/odbc-api/tests/integration.rs
+++ b/odbc-api/tests/integration.rs
@@ -1794,6 +1794,8 @@ fn read_into_columnar_buffer(profile: &Profile) {
 
     match batch.column(1) {
         AnyColumnView::Text(mut col) => {
+            assert_eq!(col.lengths(), &[13]);
+            assert_eq!(&col.values()[0..13], b"Hello, World!");
             assert_eq!(Some(&b"Hello, World!"[..]), col.next().unwrap())
         }
         _ => panic!("Unexpected buffer type"),

--- a/odbc-api/tests/integration.rs
+++ b/odbc-api/tests/integration.rs
@@ -578,7 +578,7 @@ fn columnar_fetch_varbinary(profile: &Profile) {
 
     assert_eq!(&col_it.values()[0..5], b"Hello");
     assert_eq!(&col_it.values()[10..10 + 5], b"World"); // 10 due to Varbinary(10)
-    assert_eq!(col_it.lengths(), &[5, 5]);
+    assert_eq!(col_it.lengths(), &[5, 5, -1]);
 }
 
 /// Bind a columnar buffer to a BINARY(5) column and fetch data.
@@ -703,13 +703,14 @@ fn columnar_fetch_timestamp(profile: &Profile) {
         fraction: 0,
     };
 
+    assert_eq!(&col_it.values()[..3], &[v1, v2, v3]);
+    assert_eq!(col_it.indicators()[3], -1);
+
     assert_eq!(Some(&v1), col_it.next().unwrap());
     assert_eq!(Some(&v2), col_it.next().unwrap());
     assert_eq!(Some(&v3), col_it.next().unwrap());
     assert_eq!(Some(None), col_it.next()); // Expecting NULL
     assert_eq!(None, col_it.next()); // Expecting iterator end.
-
-    assert_eq!(&col_it.values()[..3], &[v1, v2, v3])
 }
 
 /// Insert values into a DATETIME2 column using a columnar buffer


### PR DESCRIPTION
When reading the buffers to other columnar formats, an iterator of options is quite inefficient. Since this data is already initialized, we can allow the users to access it and thus can expose it in the public.