### PR TITLE
Added bench iter vs slices of indicators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,17 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
 version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
@@ -133,7 +153,7 @@ dependencies = [
  "os_str_bytes",
  "strsim",
  "termcolor",
- "textwrap",
+ "textwrap 0.14.2",
 ]
 
 [[package]]
@@ -263,6 +283,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap 2.34.0",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,7 +370,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -414,6 +514,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +588,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jni-sys"
@@ -698,6 +810,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +854,7 @@ name = "odbc-api"
 version = "0.34.1"
 dependencies = [
  "anyhow",
+ "criterion",
  "csv",
  "env_logger",
  "force-send-sync",
@@ -757,7 +880,7 @@ version = "0.3.61"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "clap",
+ "clap 3.0.14",
  "csv",
  "lazy_static",
  "log",
@@ -771,6 +894,12 @@ name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "os_str_bytes"
@@ -817,6 +946,34 @@ name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "predicates"
@@ -907,6 +1064,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,10 +1130,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -966,10 +1166,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+
+[[package]]
 name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "smallvec"
@@ -1070,6 +1308,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
@@ -1115,6 +1362,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1379,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -1142,6 +1405,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
 ]
 
 [[package]]

--- a/odbc-api/Cargo.toml
+++ b/odbc-api/Cargo.toml
@@ -28,6 +28,10 @@ readme = "../Readme.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+name = "odbc_api"
+bench = false
+
 [features]
 # Experimental feature to enabling narrow function calls.
 #
@@ -72,3 +76,8 @@ anyhow = "1.0.53"
 csv = "1.1.6"
 test-case = "1.2.3"
 tempfile = "3.3.0"
+criterion = "*"
+
+[[bench]]
+name = "slices_iterator"
+harness = false

--- a/odbc-api/benches/slices_iterator.rs
+++ b/odbc-api/benches/slices_iterator.rs
@@ -1,0 +1,96 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_iter<'a>(iter: impl Iterator<Item = Option<&'a [u8]>>) {
+    let len = iter.size_hint().0;
+    let mut offsets = Vec::with_capacity(len + 1);
+    offsets.push(0);
+    let mut values = Vec::with_capacity(0);
+    let mut validity = Vec::with_capacity(len);
+
+    let mut length = 0;
+    for item in iter {
+        if let Some(inner) = item {
+            length += inner.len();
+            validity.push(true);
+            values.extend_from_slice(inner)
+        } else {
+            validity.push(false);
+        }
+        offsets.push(length);
+    }
+}
+
+fn bench_slices(slice: &[u8], indicators: &[isize], max_length: usize) {
+    let len = indicators.len();
+    let mut offsets = Vec::with_capacity(len + 1);
+    offsets.push(0);
+    let mut validity = Vec::with_capacity(len);
+
+    let mut length = 0;
+    let max_length_i = max_length as isize;
+    offsets.extend(indicators.iter().map(|&indicator| {
+        validity.push(indicator != -1);
+        length += if indicator > 0 && indicator <= max_length_i {
+            indicator as i32
+        } else {
+            0
+        };
+        length
+    }));
+
+    assert_eq!(slice.len(), max_length * indicators.len());
+    let mut values = Vec::<u8>::with_capacity(length as usize);
+    offsets.windows(2).enumerate().for_each(|(index, x)| {
+        let len = (x[1] - x[0]) as usize;
+        let offset = index * max_length;
+
+        // this is proven because:
+        // last offset == (indicators.len() - 1) * max_length
+        // last length <= max_length;
+        let slice = unsafe { slice.get_unchecked(offset..offset + len) };
+        values.extend_from_slice(slice);
+    });
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let num_rows = 2usize.pow(log2_size);
+        let max_len = 40;
+        // 1 every 10 is null
+        let is_null = |x: usize| x % 10 == 0;
+
+        let col = odbc_api::buffers::BinColumn {
+            max_len,
+            values: (0..max_len * num_rows).map(|x| (x % 255) as u8).collect(),
+            indicators: (0..num_rows)
+                .map(|x| {
+                    if is_null(x) {
+                        -1
+                    } else {
+                        (x % (max_len + 1)) as isize
+                    }
+                })
+                .collect(),
+        };
+
+        c.bench_function(&format!("iter 2^{}", log2_size), |b| {
+            b.iter(|| {
+                let iter = odbc_api::buffers::BinColumnIt {
+                    pos: 0,
+                    num_rows,
+                    col: &col,
+                };
+                bench_iter(iter);
+            })
+        });
+
+        c.bench_function(&format!("slices 2^{}", log2_size), |b| {
+            b.iter(|| {
+                bench_slices(&col.values, &col.indicators, col.max_len);
+            })
+        });
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/odbc-api/src/buffers/bin_column.rs
+++ b/odbc-api/src/buffers/bin_column.rs
@@ -15,12 +15,12 @@ use std::{cmp::min, ffi::c_void};
 #[derive(Debug)]
 pub struct BinColumn {
     /// Maximum element length.
-    max_len: usize,
-    values: Vec<u8>,
+    pub max_len: usize,
+    pub values: Vec<u8>,
     /// Elements in this buffer are either `NULL_DATA` or hold the length of the element in value
     /// with the same index. Please note that this value may be larger than `max_len` if the value
     /// has been truncated.
-    indicators: Vec<isize>,
+    pub indicators: Vec<isize>,
 }
 
 impl BinColumn {
@@ -214,9 +214,9 @@ impl BinColumn {
 /// Iterator over a binary column. See [`crate::buffers::AnyColumnView`]
 #[derive(Debug)]
 pub struct BinColumnIt<'c> {
-    pos: usize,
-    num_rows: usize,
-    col: &'c BinColumn,
+    pub pos: usize,
+    pub num_rows: usize,
+    pub col: &'c BinColumn,
 }
 
 impl<'c> Iterator for BinColumnIt<'c> {


### PR DESCRIPTION
This draft PR contains a bench comparing creating an arrow-aligned data via two different strategies:

* `iter` creates arrow-aligned data using the current iterator API, iterating item by item and re-allocating the values when needed
* `slices` uses slices directly.

The overall difference is about -15%; this jumps to -50% (2x) when we require a large reallocation (i.e. when there is already a large values and we need to re-allocate it). IM understanding, whether such large re-allocations happens depend non-trivially on `max_len`, batch size, and allocation strategy.

(on a `skylane-avx512`)
```
iter 2^10               time:   [6.6819 us 6.7897 us 6.9784 us]                       
slices 2^10             time:   [5.9562 us 6.0251 us 6.1279 us]                         
iter 2^12               time:   [27.062 us 27.474 us 27.991 us]                       
slices 2^12             time:   [23.801 us 24.171 us 24.717 us]                         
iter 2^14               time:   [110.17 us 112.35 us 115.40 us]                      
slices 2^14             time:   [93.638 us 95.185 us 97.643 us]                   
iter 2^16               time:   [434.89 us 441.81 us 451.06 us]                     
slices 2^16             time:   [376.38 us 383.16 us 392.67 us]                        
iter 2^18               time:   [1.8616 ms 1.8914 ms 1.9254 ms]                       
slices 2^18             time:   [1.5660 ms 1.5876 ms 1.6173 ms]                         
iter 2^20               time:   [24.864 ms 25.166 ms 25.543 ms]                      
slices 2^20             time:   [10.933 ms 11.028 ms 11.144 ms]     
```


This is not mergeable as it marks implementation details as public (so that we can access for the purpose of the bench) 