### PR TITLE
Explicit lifetime declaration of `StatementImpl`

### DIFF
--- a/odbc-api/src/connection.rs
+++ b/odbc-api/src/connection.rs
@@ -110,7 +110,7 @@ impl<'c> Connection<'c> {
         &self,
         query: &str,
         params: impl ParameterRefCollection,
-    ) -> Result<Option<CursorImpl<StatementImpl<'_>>>, Error> {
+    ) -> Result<Option<CursorImpl<StatementImpl<'c>>>, Error> {
         let query = SqlText::new(query);
         let lazy_statement = move || self.allocate_statement();
         execute_with_parameters(lazy_statement, Some(&query), params)
@@ -574,7 +574,7 @@ impl<'c> Connection<'c> {
         ])
     }
 
-    fn allocate_statement(&self) -> Result<StatementImpl<'_>, Error> {
+    fn allocate_statement(&self) -> Result<StatementImpl<'c>, Error> {
         self.connection
             .allocate_statement()
             .into_result(&self.connection)

--- a/odbc-api/src/handles/connection.rs
+++ b/odbc-api/src/handles/connection.rs
@@ -160,7 +160,7 @@ impl<'c> Connection<'c> {
     }
 
     /// Allocate a new statement handle. The `Statement` must not outlive the `Connection`.
-    pub fn allocate_statement(&self) -> SqlResult<StatementImpl<'_>> {
+    pub fn allocate_statement(&self) -> SqlResult<StatementImpl<'c>> {
         let mut out = null_mut();
         unsafe {
             SQLAllocHandle(HandleType::Stmt, self.as_handle(), &mut out)


### PR DESCRIPTION
As far as I understand it, `StatementImpl` is bound to the connection, which is ultimately bound to the environment. This small PR makes it so that `Connection::execute` explicitly bounds the lifetime of `StatementImpl` to the connection's own lifetime.

Without this PR, the `StatementImpl`'s lifetime was getting anonymously bound to the parameters of the `execute`, which may not outlive the lifetime of the connection.

The below snipped is currently failing to compile:

```rust
use arrow2::io::odbc;

type CCursor<'a> = odbc::api::RowSetCursor<
    odbc::api::CursorImpl<odbc::api::handles::StatementImpl<'a>>,
    odbc::api::buffers::ColumnarBuffer<odbc::api::buffers::AnyColumnBuffer>,
>;

struct ChunkIterator<'a> {
    cursor: CCursor<'a>,
    fields: Vec<Field>,
}

impl<'a> ChunkIterator<'a> {
    fn new(cursor: CCursor<'a>, fields: Vec<Field>) -> Self {
        Self { cursor, fields }
    }
}

/// returns an iterator over chunks coming from the ODBC driver
fn read<'a>(
    connection: &odbc::api::Connection<'a>,
    query: &str,
    batch_size: usize,
) -> Result<Option<ChunkIterator<'a>>, Error> {
    let cursor = connection.execute(query, ())?;
    let cursor = if let Some(cursor) = cursor {
        cursor
    } else {
        return Ok(None);
    };
    let fields = odbc::read::infer_schema(&cursor)?;

    let buffer = odbc::read::buffer_from_metadata(&cursor, batch_size)?;

    let cursor = cursor.bind_buffer(buffer)?;

    Ok(Some(ChunkIterator::new(cursor, fields)))
}
```

`ChunkIterator` is an iterator that fetches from cursor and performs some CPU-bound work. Its lifetime does not need to be associated with the reference in `connection: &`, it only needs to be associated to `'a`.