### PR TITLE
use stable toolchain for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
 
       # LLVM tools preview is a requirement of cargo-llvm-cov
       - name: Install llvm-tools-preview
-        run: rustup toolchain install nightly-2022-01-06 --component llvm-tools-preview
+        run: rustup toolchain install stable --component llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       # We currently do not test against PostgreSQL, but the time will come leave this
@@ -62,9 +62,9 @@ jobs:
       # Maria DB test currently do not run due to a packaging error of their odbc driver
       - name: Generate coverage report
         run: | 
-          cargo +nightly-2022-01-06 llvm-cov --no-report -- --skip maria_db
-          cargo +nightly-2022-01-06 llvm-cov --features narrow --no-report -- --skip maria_db
-          cargo +nightly-2022-01-06 llvm-cov --no-run --lcov --output-path lcov.info
+          cargo llvm-cov --no-report -- --skip maria_db
+          cargo llvm-cov --features narrow --no-report -- --skip maria_db
+          cargo llvm-cov --no-run --lcov --output-path lcov.info
       - name: Push coverage results to Coveralls
         uses: coverallsapp/github-action@v1.0.1
         with:


### PR DESCRIPTION
Fixed nightly version used for coverage got outdated. Lucky for us, by now stable seems to be able to work just fine.