### PR TITLE
fix maybe missing odbc-api 0.49.0 tag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.48.1
+## 0.49.0
 
 * Asynchronous execution of one shot queries using `Connection::execute_polling`.
 * Asynchronous bulk fetching of results using `RowSetCursorPolling`.


### PR DESCRIPTION
Hi, @pacman82 
I noticed that, https://crates.io/crates/odbc-api/0.49.0 has been released, not exist `0.48.1` version.
And now the `odbc-api repository` has a 0.48.1 tag. Did you miss the 0.49.0 tag? 