### PR TITLE
reduce calls to SQLGetDiagRec

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.50.0 (next)
+## 0.50.0
+
+* Fetching diagnostic records now starts with a message buffer size of 512 instead of 0 in order to recduce calls to `SQLGetDiagRec`.
 
 ### Breaking
 

--- a/odbc-api/src/environment.rs
+++ b/odbc-api/src/environment.rs
@@ -2,7 +2,9 @@ use std::{cmp::max, collections::HashMap, ptr::null_mut, sync::Mutex};
 
 use crate::{
     error::ExtendResult,
-    handles::{self, log_diagnostics, OutputStringBuffer, SqlResult, SqlText, State, SzBuffer},
+    handles::{
+        self, log_diagnostics, OutputStringBuffer, SqlResult, SqlText, State, SzBuffer,
+    },
     Connection, DriverCompleteOption, Error,
 };
 use log::debug;

--- a/odbc-api/src/error.rs
+++ b/odbc-api/src/error.rs
@@ -229,7 +229,7 @@ impl<T> SqlResult<T> {
                 Ok(value)
             }
             SqlResult::Error { function } => {
-                let mut record = DiagnosticRecord::default();
+                let mut record = DiagnosticRecord::with_capacity(512);
                 if record.fill_from(handle, 1) {
                     log_diagnostics(handle);
                     Err(Error::Diagnostics { record, function })

--- a/odbc-api/src/handles/diagnostics.rs
+++ b/odbc-api/src/handles/diagnostics.rs
@@ -226,6 +226,16 @@ pub struct Record {
 }
 
 impl Record {
+    /// Creates an empty diagnostic record with at least the specified capacity for the message.
+    /// Using a buffer with a size different from zero then filling the diagnostic record may safe a
+    /// second function call to `SQLGetDiagRec`.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            message: Vec::with_capacity(capacity),
+            ..Default::default()
+        }
+    }
+
     /// Fill this diagnostic `Record` from any ODBC handle.
     ///
     /// # Return

--- a/odbc-api/src/handles/logging.rs
+++ b/odbc-api/src/handles/logging.rs
@@ -1,4 +1,4 @@
-use super::{diagnostics::Record, Diagnostics};
+use super::{Diagnostics, Record};
 use log::{warn, Level};
 
 /// This function inspects all the diagnostics of an ODBC handle and logs their text messages. It
@@ -10,8 +10,8 @@ pub fn log_diagnostics(handle: &(impl Diagnostics + ?Sized)) {
         return;
     }
 
+    let mut rec = Record::with_capacity(512);
     let mut rec_number = 1;
-    let mut rec = Record::default();
 
     // Log results, while there are diagnostic records
     while rec.fill_from(handle, rec_number) {

--- a/odbcsv/src/main.rs
+++ b/odbcsv/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, bail, Error};
-use clap::{Args, Parser, ArgAction};
+use clap::{ArgAction, Args, Parser};
 use log::info;
 use odbc_api::{
     buffers::TextRowSet, escape_attribute_value, handles::OutputStringBuffer, Connection, Cursor,


### PR DESCRIPTION
Makes sense, even independently from #266. If it turns out it helps poor souls using erroneous drivers, which delete messages then fetching with an empty message buffer as a workaround, thats a plus.