### PR TITLE
add nix flake install instructions to readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,7 +132,7 @@ $ cd ./result
 $ ls
 ```
 
-The `openssl` version may need to change as well or may not be needed at all for other drivers. I have not tested the above `flake.nix` with other drivers or on OS-X. At a minimum, the `LD_LIBRARY_PATH` will need to change to `DYLD_FALLBACK_LIBRARY_PATH`.
+The `openssl` version may need to change as well or may not be needed at all for other drivers. I have not tested the above `flake.nix` with other drivers or on OS-X. At a minimum in OS-X, the `LD_LIBRARY_PATH` will need to change to `DYLD_FALLBACK_LIBRARY_PATH`.
 
 ## Features
 

--- a/Readme.md
+++ b/Readme.md
@@ -86,8 +86,6 @@ Here is an example of a `flake.nix` that sets up a dev environment for `odbc-api
         };
       in
       {
-        # For odbc-api to work it needs openssl 1.1 and unixODBC bying in the
-        # LD_LIBRARY_PATH and odbcinst.ini contents and location need to be set.
         devShell = pkgs.mkShell {
           shellHook = with pkgs; ''
             export LD_LIBRARY_PATH="${unixODBC}/lib:${openssl_1_1.out}/lib";
@@ -126,7 +124,7 @@ Nix flakes depend on `git` and are not aware of files not staged or committed, t
 
 The `flake.nix` above will require some modifications to work with other ODBC drivers. For example, replacing `ODBC Driver 17 for SQL Server` with one of `PostgreSQL`, `MariaDB`, or `SQLite`. And `unixODBCDrivers.msodbcsql17` with one of the [other drivers](https://search.nixos.org/options?channel=unstable&show=environment.unixODBCDrivers&from=0&size=50&sort=relevance&type=packages&query=unixODBCDrivers) such as `mariadb`, `psql` or `sqlite`.
 
-The hard coded driver path will need to be changed as well for other drivers. One can figure this out path by a combination of looking at the [nixpkgs source](https://github.com/NixOS/nixpkgs/blob/456d8190ad756a30d69064381b5149bceabc14a6/pkgs/development/libraries/unixODBCDrivers/default.nix#L62) and / or evaluating the package:
+The hard coded driver path will need to be changed as well for other drivers. One can figure out the path by a combination of looking at the [nixpkgs source](https://github.com/NixOS/nixpkgs/blob/456d8190ad756a30d69064381b5149bceabc14a6/pkgs/development/libraries/unixODBCDrivers/default.nix#L62) and / or evaluating the package:
 
 ```shell
 $ nix-build '<nixpkgs>' -A unixODBCDrivers.mariadb

--- a/Readme.md
+++ b/Readme.md
@@ -93,7 +93,7 @@ Here is an example of a `flake.nix` that sets up a dev environment for `odbc-api
             export LD_LIBRARY_PATH="${unixODBC}/lib:${openssl_1_1.out}/lib";
 
             # Make rust build directory if it doesn't already exist
-            mkdir ./target
+            mkdir -p ./target
 
             # see https://www.systutorials.com/docs/linux/man/7-unixODBC/
             # Overloads path to unixODBC configuration files. By default equals to '/etc'.

--- a/Readme.md
+++ b/Readme.md
@@ -126,7 +126,7 @@ Nix flakes depend on `git` and are not aware of files not staged or committed, t
 
 The `flake.nix` above will require some modifications to work with other ODBC drivers. For example, replacing `ODBC Driver 17 for SQL Server` with one of `PostgreSQL`, `MariaDB`, or `SQLite`. And `unixODBCDrivers.msodbcsql17` with one of the [other drivers](https://search.nixos.org/options?channel=unstable&show=environment.unixODBCDrivers&from=0&size=50&sort=relevance&type=packages&query=unixODBCDrivers) such as `mariadb`, `psql` or `sqlite`.
 
-The hard coded driver path will need to be changed as well for other drivers. One can figure out this path by a combination of looking at the [nixpkgs source](https://github.com/NixOS/nixpkgs/blob/456d8190ad756a30d69064381b5149bceabc14a6/pkgs/development/libraries/unixODBCDrivers/default.nix#L62) and / or evaluating the package:
+The hard coded driver path will need to be changed as well for other drivers. One can figure this out path by a combination of looking at the [nixpkgs source](https://github.com/NixOS/nixpkgs/blob/456d8190ad756a30d69064381b5149bceabc14a6/pkgs/development/libraries/unixODBCDrivers/default.nix#L62) and / or evaluating the package:
 
 ```shell
 $ nix-build '<nixpkgs>' -A unixODBCDrivers.mariadb

--- a/Readme.md
+++ b/Readme.md
@@ -132,7 +132,7 @@ $ cd ./result
 $ ls
 ```
 
-The `openssl` version may need to change as well or may not be needed at all for other drivers. I have not tested the above `flake.nix` with other drivers or on OS-X.
+The `openssl` version may need to change as well or may not be needed at all for other drivers. I have not tested the above `flake.nix` with other drivers or on OS-X. At a minimum, the `LD_LIBRARY_PATH` will need to change to `DYLD_FALLBACK_LIBRARY_PATH`.
 
 ## Features
 

--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,85 @@ You can also install unixODBC from source:
 5. `make`
 6. `make install`
 
+### Non-system wide installation with Nix Flakes
+
+On Linux and OS-X one can install the Nix package manager:
+
+- The [unofficial installer](https://zero-to-nix.com/start/install)
+- Or the [official installer](https://nixos.org/download.html)
+
+The unofficial installer has better capability to roll back the installation and enables nix flakes by default. The official installer requires [extra steps](https://nixos.wiki/wiki/Flakes) to enable flakes.
+
+Here is an example of a `flake.nix` that sets up a dev environment for `odbc-api` for use with the ODBC Driver 17 for SQL Server:
+
+```nix
+{
+  description = "Setup a devShell for odbc-api";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+      in
+      {
+        # For odbc-api to work it needs openssl 1.1 and unixODBC bying in the
+        # LD_LIBRARY_PATH and odbcinst.ini contents and location need to be set.
+        devShell = pkgs.mkShell {
+          shellHook = with pkgs; ''
+            export LD_LIBRARY_PATH="${unixODBC}/lib:${openssl_1_1.out}/lib";
+
+            # Make rust build directory if it doesn't already exist
+            mkdir ./target
+
+            # see https://www.systutorials.com/docs/linux/man/7-unixODBC/
+            # Overloads path to unixODBC configuration files. By default equals to '/etc'.
+            export ODBCSYSINI=$(realpath ./target)
+
+            echo "[ODBC Driver 17 for SQL Server]" > ./target/odbcinst.ini
+            echo "Description = ODBC Driver 17 for SQL Server" >> ./target/odbcinst.ini
+            echo "Driver = ${unixODBCDrivers.msodbcsql17}/lib/libmsodbcsql-17.7.so.1.1" >> ./target/odbcinst.ini
+          '';
+        };
+      });
+}
+```
+
+Add this as `flake.nix` to the root of your rust project, stage it in `git`, and run `nix develop` to enter the devShell.
+
+For example:
+
+```shell
+$ cargo new odbc-tester
+$ cd odbc-tester
+$ cargo add odbc-api
+$ touch flake.nix # And paste the above flake.nix into it
+$ git init
+$ git add -A
+$ nix develop
+```
+
+Nix flakes depend on `git` and are not aware of files not staged or committed, this is why `git add -A` is needed to stage the `flake.nix` file. Otherwise, `nix develop` will fail.
+
+The `flake.nix` above will require some modifications to work with other ODBC drivers. For example, replacing `ODBC Driver 17 for SQL Server` with one of `PostgreSQL`, `MariaDB`, or `SQLite`. And `unixODBCDrivers.msodbcsql17` with one of the [other drivers](https://search.nixos.org/options?channel=unstable&show=environment.unixODBCDrivers&from=0&size=50&sort=relevance&type=packages&query=unixODBCDrivers) such as `mariadb`, `psql` or `sqlite`.
+
+The hard coded driver path will need to be changed as well for other drivers. One can figure out this path by a combination of looking at the [nixpkgs source](https://github.com/NixOS/nixpkgs/blob/456d8190ad756a30d69064381b5149bceabc14a6/pkgs/development/libraries/unixODBCDrivers/default.nix#L62) and / or evaluating the package:
+
+```shell
+$ nix-build '<nixpkgs>' -A unixODBCDrivers.mariadb
+$ cd ./result
+$ ls
+```
+
+The `openssl` version may need to change as well or may not be needed at all for other drivers. I have not tested the above `flake.nix` with other drivers or on OS-X.
+
 ## Features
 
 * [x] Connect using Data Source names (DSN)


### PR DESCRIPTION
Thought I'd share some experiences with how I got this library working in NixOS using nix flakes. This should work fine in other Linux distributions, but I don't have a way to test it in OS-X so minor changes may be needed for that. For example, `LD_LIBRARY_PATH` may need to change in that OS. Let me know what you think!