### PR TITLE
fix: Decimal conversion with too many low digits

### DIFF
--- a/odbc-api/src/conversion.rs
+++ b/odbc-api/src/conversion.rs
@@ -193,7 +193,6 @@ mod tests {
     }
 
     #[test]
-
     fn decimal_with_too_much_scale() {
         let actual = decimal_text_to_i128(b"10.000000", 5);
 
@@ -201,7 +200,6 @@ mod tests {
     }
 
     #[test]
-
     fn decimal_with_too_much_scale_negative() {
         let actual = decimal_text_to_i128(b"-10.123456", 5);
 
@@ -209,7 +207,6 @@ mod tests {
     }
 
     #[test]
-
     fn decimal_with_too_much_scale_small_negative() {
         let actual = decimal_text_to_i128(b"-0.123456", 5);
 


### PR DESCRIPTION
## 🗣 Description

* Truncates decimal conversion for situations where the number of low digits are more than the specified scale.

For example, when performing an `avg()` query with a decimal source column, the output avg column receives a scale of `(_, 6)` but the actual data received was a decimal with 16 fractional digits (e.g. `12.3456789000000000`). In this example, we truncate the digits to the specified scale for the field leaving behind the actual data of `12.345678`.

Depending on the query, the existing behavior can result in panics from subtraction overflow. For example: https://github.com/spiceai/spiceai/issues/1907