### PR TITLE
move prompting for connection string to "prompt" feature

### DIFF
--- a/odbc-api/Cargo.toml
+++ b/odbc-api/Cargo.toml
@@ -77,7 +77,9 @@ iodbc = ["odbc_version_3_5", "narrow", "odbc-sys/iodbc"]
 # Allows deriving custom implementations of `FetchRow` for row wise bulk fetching.
 derive = ["dep:odbc-api-derive"]
 
-default=["odbc_version_3_80"]
+default=["odbc_version_3_80", "prompt"]
+
+prompt=["dep:winit"]
 
 [dependencies]
 # Low level bindings to ODBC API calls into libodbc.so
@@ -95,7 +97,7 @@ odbc-api-derive ={ version = "11.0.2", path = "../derive", optional = true}
 # We use winit to display dialogs prompting for connection strings. We can deactivate default
 # features since it can work only on windows and therfore we do not need any dependencies
 # associated with various window managers.
-winit = { version = "0.30.10", default-features = false, features = ["rwh_06"]}
+winit = { version = "0.30.10", default-features = false, features = ["rwh_06"], optional = true}
 
 [dev-dependencies]
 env_logger = "0.11.6"

--- a/odbc-api/src/driver_complete_option.rs
+++ b/odbc-api/src/driver_complete_option.rs
@@ -7,12 +7,15 @@ pub enum DriverCompleteOption {
     /// This is the only supported variant on non windows platforms
     NoPrompt,
     /// Always show a prompt to the user.
+    #[cfg(all(target_os = "windows", feature = "prompt"))]
     Prompt,
     /// Only show a prompt to the user if the information in the connection string is not sufficient
     /// to connect to the data source.
+    #[cfg(all(target_os = "windows", feature = "prompt"))]
     Complete,
     /// Like complete, but the user may not change any information already provided within the
     /// connection string.
+    #[cfg(all(target_os = "windows", feature = "prompt"))]
     CompleteRequired,
 }
 
@@ -20,8 +23,11 @@ impl DriverCompleteOption {
     pub fn as_sys(&self) -> odbc_sys::DriverConnectOption {
         match self {
             DriverCompleteOption::NoPrompt => odbc_sys::DriverConnectOption::NoPrompt,
+            #[cfg(all(target_os = "windows", feature = "prompt"))]
             DriverCompleteOption::Prompt => odbc_sys::DriverConnectOption::Prompt,
+            #[cfg(all(target_os = "windows", feature = "prompt"))]
             DriverCompleteOption::Complete => odbc_sys::DriverConnectOption::Complete,
+            #[cfg(all(target_os = "windows", feature = "prompt"))]
             DriverCompleteOption::CompleteRequired => {
                 odbc_sys::DriverConnectOption::CompleteRequired
             }

--- a/odbc-api/src/environment.rs
+++ b/odbc-api/src/environment.rs
@@ -757,14 +757,4 @@ mod tests {
         assert_eq!(attributes["SQLLevel"], "1");
         assert_eq!(attributes["UsageCount"], "1");
     }
-
-    #[cfg(not(target_os = "windows"))]
-    #[test]
-    #[should_panic(expected = "Prompt is not supported for non-windows systems.")]
-    fn driver_connect_with_prompt_panics_under_linux() {
-        let env = Environment::new().unwrap();
-        let mut out = OutputStringBuffer::empty();
-        env.driver_connect("", &mut out, DriverCompleteOption::Prompt)
-            .unwrap();
-    }
 }

--- a/odbc-api/src/environment.rs
+++ b/odbc-api/src/environment.rs
@@ -328,7 +328,10 @@ impl Environment {
     /// let connection = env.driver_connect(
     ///     "",
     ///     &mut output_buffer,
+    ///     #[cfg(target_os = "windows")]
     ///     DriverCompleteOption::Prompt,
+    ///     #[cfg(not(target_os = "windows"))]
+    ///     DriverCompleteOption::NoPrompt,
     /// )?;
     ///
     /// // Check that the output buffer has been large enough to hold the entire connection string.

--- a/odbc-api/src/environment.rs
+++ b/odbc-api/src/environment.rs
@@ -17,7 +17,7 @@ use crate::{
 use log::debug;
 use odbc_sys::{AttrCpMatch, AttrOdbcVersion, FetchOrientation, HWnd};
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", feature = "prompt"))]
 // Currently only windows driver manager supports prompt.
 use winit::{
     application::ApplicationHandler,
@@ -403,7 +403,7 @@ impl Environment {
 
         match driver_completion {
             DriverCompleteOption::NoPrompt => (),
-            #[cfg(target_os = "windows")]
+            #[cfg(all(target_os = "windows", feature = "prompt"))]
             _ => {
                 // We need a parent window, let's provide a message only window.
                 let mut window_app = MessageOnlyWindowEventHandler {
@@ -414,8 +414,6 @@ impl Environment {
                 event_loop.run_app_on_demand(&mut window_app).unwrap();
                 return window_app.result.unwrap();
             }
-            #[cfg(not(target_os = "windows"))]
-            _ => panic!("Prompt is not supported for non-windows systems."),
         };
         let hwnd = null_mut();
         driver_connect(hwnd)
@@ -694,13 +692,13 @@ pub struct DataSourceInfo {
 }
 
 /// Message loop for prompt dialog. Used by [`Environment::driver_connect`].
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", feature = "prompt"))]
 struct MessageOnlyWindowEventHandler<'a, F> {
     run_prompt_dialog: Option<F>,
     result: Option<Result<Connection<'a>, Error>>,
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", feature = "prompt"))]
 impl<'a, F> ApplicationHandler for MessageOnlyWindowEventHandler<'a, F>
 where
     F: FnOnce(HWnd) -> Result<Connection<'a>, Error>,


### PR DESCRIPTION
Hi!
I have a proposal to move the prompt stuff into a default feature so people who don't want to use it can get rid of the winit dependency.

My virus scanner dislikes the winit build script binaries and when checking how it was used (as I didn't expect this library to need a window handler lib) I figured this would probably be a good idea.

This way the feature would stay for everyone currently using it, and the only people affected with breakage are people who handled the enum variants for the Prompt options explicitly on platforms it wasn't used on anyway.

If you want I can move the enum stuff back to being a runtime panic, but considering it's not available on any other platform i'd recommend going with the breaking change + this config gating.