### PR TITLE
dev

### DIFF
--- a/odbc-api/src/catalog/columns.rs
+++ b/odbc-api/src/catalog/columns.rs
@@ -1,7 +1,7 @@
 use crate::{
     CursorImpl, Error, Nullable, TruncationInfo,
     buffers::{FetchRow, FetchRowMember as _},
-    handles::{AsStatementRef, SqlText, Statement, StatementRef},
+    handles::{SqlText, Statement, StatementRef},
     parameter::VarCharArray,
 };
 
@@ -153,15 +153,14 @@ pub fn execute_columns<S>(
     column_name: &SqlText,
 ) -> Result<CursorImpl<S>, Error>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
-    let mut stmt = statement.as_stmt_ref();
-
-    stmt.columns(catalog_name, schema_name, table_name, column_name)
-        .into_result(&stmt)?;
+    statement
+        .columns(catalog_name, schema_name, table_name, column_name)
+        .into_result(&statement)?;
 
     // We assume columns always creates a result set, since it works like a SELECT statement.
-    debug_assert_ne!(stmt.num_result_cols().unwrap(), 0);
+    debug_assert_ne!(statement.num_result_cols().unwrap(), 0);
 
     // Safe: `statement` is in cursor state
     let cursor = unsafe { CursorImpl::new(statement) };

--- a/odbc-api/src/catalog/foreign_keys.rs
+++ b/odbc-api/src/catalog/foreign_keys.rs
@@ -1,7 +1,7 @@
 use crate::{
     CursorImpl, Error, Nullable, TruncationInfo,
     buffers::{FetchRow, FetchRowMember as _},
-    handles::{AsStatementRef, SqlText, Statement, StatementRef},
+    handles::{SqlText, Statement, StatementRef},
     parameter::VarCharArray,
 };
 
@@ -122,22 +122,21 @@ pub fn execute_foreign_keys<S>(
     fk_table_name: &str,
 ) -> Result<CursorImpl<S>, Error>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
-    let mut stmt = statement.as_stmt_ref();
-
-    stmt.foreign_keys(
-        &SqlText::new(pk_catalog_name),
-        &SqlText::new(pk_schema_name),
-        &SqlText::new(pk_table_name),
-        &SqlText::new(fk_catalog_name),
-        &SqlText::new(fk_schema_name),
-        &SqlText::new(fk_table_name),
-    )
-    .into_result(&stmt)?;
+    statement
+        .foreign_keys(
+            &SqlText::new(pk_catalog_name),
+            &SqlText::new(pk_schema_name),
+            &SqlText::new(pk_table_name),
+            &SqlText::new(fk_catalog_name),
+            &SqlText::new(fk_schema_name),
+            &SqlText::new(fk_table_name),
+        )
+        .into_result(&statement)?;
 
     // We assume foreign keys always creates a result set, since it works like a SELECT statement.
-    debug_assert_ne!(stmt.num_result_cols().unwrap(), 0);
+    debug_assert_ne!(statement.num_result_cols().unwrap(), 0);
 
     // Safe: `statement` is in Cursor state.
     let cursor = unsafe { CursorImpl::new(statement) };

--- a/odbc-api/src/catalog/primary_keys.rs
+++ b/odbc-api/src/catalog/primary_keys.rs
@@ -1,7 +1,7 @@
 use crate::{
     CursorImpl, Error, TruncationInfo,
     buffers::{FetchRow, FetchRowMember as _},
-    handles::{AsStatementRef, SqlText, Statement, StatementRef},
+    handles::{SqlText, Statement, StatementRef},
     parameter::VarCharArray,
 };
 
@@ -81,15 +81,15 @@ pub fn execute_primary_keys<S>(
     table_name: &str,
 ) -> Result<CursorImpl<S>, Error>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
-    let mut stmt = statement.as_stmt_ref();
-    stmt.primary_keys(
-        catalog_name.map(SqlText::new).as_ref(),
-        schema_name.map(SqlText::new).as_ref(),
-        &SqlText::new(table_name),
-    )
-    .into_result(&stmt)?;
+    statement
+        .primary_keys(
+            catalog_name.map(SqlText::new).as_ref(),
+            schema_name.map(SqlText::new).as_ref(),
+            &SqlText::new(table_name),
+        )
+        .into_result(&statement)?;
     // SAFETY: primary_keys puts stmt into cursor state.
     let cursor = unsafe { CursorImpl::new(statement) };
     Ok(cursor)

--- a/odbc-api/src/catalog/tables.rs
+++ b/odbc-api/src/catalog/tables.rs
@@ -1,7 +1,7 @@
 use crate::{
     CursorImpl, Error, TruncationInfo,
     buffers::{FetchRow, FetchRowMember as _},
-    handles::{AsStatementRef, SqlText, Statement, StatementRef},
+    handles::{SqlText, Statement, StatementRef},
     parameter::VarCharArray,
 };
 
@@ -63,20 +63,19 @@ pub fn execute_tables<S>(
     table_type: &str,
 ) -> Result<CursorImpl<S>, Error>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
-    let mut stmt = statement.as_stmt_ref();
-
-    stmt.tables(
-        &SqlText::new(catalog_name),
-        &SqlText::new(schema_name),
-        &SqlText::new(table_name),
-        &SqlText::new(table_type),
-    )
-    .into_result(&stmt)?;
+    statement
+        .tables(
+            &SqlText::new(catalog_name),
+            &SqlText::new(schema_name),
+            &SqlText::new(table_name),
+            &SqlText::new(table_type),
+        )
+        .into_result(&statement)?;
 
     // We assume tables always creates a result set, since it works like a SELECT statement.
-    debug_assert_ne!(stmt.num_result_cols().unwrap(), 0);
+    debug_assert_ne!(statement.num_result_cols().unwrap(), 0);
 
     // Safe: `statement` is in Cursor state.
     let cursor = unsafe { CursorImpl::new(statement) };

--- a/odbc-api/src/cursor.rs
+++ b/odbc-api/src/cursor.rs
@@ -335,7 +335,11 @@ where
     S: Statement,
 {
     fn drop(&mut self) {
-        if let Err(e) = self.statement.close_cursor().into_result(&self.statement) {
+        if let Err(e) = self
+            .statement
+            .end_cursor_scope()
+            .into_result(&self.statement)
+        {
             // Avoid panicking, if we already have a panic. We don't want to mask the original
             // error.
             if !panicking() {

--- a/odbc-api/src/cursor.rs
+++ b/odbc-api/src/cursor.rs
@@ -98,10 +98,6 @@ pub trait Cursor: ResultSetMetadata {
     fn more_results(self) -> Result<Option<Self>, Error>
     where
         Self: Sized;
-
-    /// Close the current cursor explicitly. Allows application to handle errors emitted by
-    /// `SQLCloseCursor`.
-    fn close(self) -> Result<(), Error>;
 }
 
 /// An individual row of an result set. See [`crate::Cursor::next_row`].
@@ -391,13 +387,6 @@ where
             None
         };
         Ok(next)
-    }
-
-    fn close(self) -> Result<(), Error> {
-        let mut stmt = self.into_stmt();
-        let mut stmt = stmt.as_stmt_ref();
-        stmt.close_cursor().into_result(&stmt)?;
-        Ok(())
     }
 }
 

--- a/odbc-api/src/cursor.rs
+++ b/odbc-api/src/cursor.rs
@@ -325,18 +325,17 @@ impl CursorRow<'_> {
 /// by either a prepared query or direct execution. Usually utilized through the [`crate::Cursor`]
 /// trait.
 #[derive(Debug)]
-pub struct CursorImpl<Stmt: AsStatementRef> {
+pub struct CursorImpl<Stmt: Statement> {
     /// A statement handle in cursor mode.
     statement: Stmt,
 }
 
 impl<S> Drop for CursorImpl<S>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     fn drop(&mut self) {
-        let mut stmt = self.statement.as_stmt_ref();
-        if let Err(e) = stmt.close_cursor().into_result(&stmt) {
+        if let Err(e) = self.statement.close_cursor().into_result(&self.statement) {
             // Avoid panicking, if we already have a panic. We don't want to mask the original
             // error.
             if !panicking() {
@@ -348,18 +347,18 @@ where
 
 impl<S> AsStatementRef for CursorImpl<S>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     fn as_stmt_ref(&mut self) -> StatementRef<'_> {
         self.statement.as_stmt_ref()
     }
 }
 
-impl<S> ResultSetMetadata for CursorImpl<S> where S: AsStatementRef {}
+impl<S> ResultSetMetadata for CursorImpl<S> where S: Statement {}
 
 impl<S> Cursor for CursorImpl<S>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     fn bind_buffer<B>(mut self, mut row_set_buffer: B) -> Result<BlockCursor<Self, B>, Error>
     where
@@ -378,9 +377,9 @@ where
     {
         // Consume self without calling drop to avoid calling close_cursor.
         let mut statement = self.into_stmt();
-        let mut stmt = statement.as_stmt_ref();
 
-        let has_another_result = unsafe { stmt.more_results() }.into_result_bool(&stmt)?;
+        let has_another_result =
+            unsafe { statement.more_results() }.into_result_bool(&statement)?;
         let next = if has_another_result {
             Some(CursorImpl { statement })
         } else {
@@ -392,7 +391,7 @@ where
 
 impl<S> CursorImpl<S>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     /// Users of this library are encouraged not to call this constructor directly but rather invoke
     /// [`crate::Connection::execute`] or [`crate::Prepared::execute`] to get a cursor and utilize

--- a/odbc-api/src/cursor/polling_cursor.rs
+++ b/odbc-api/src/cursor/polling_cursor.rs
@@ -16,14 +16,14 @@ use std::thread::panicking;
 ///
 /// Like [`super::CursorImpl`] this is an ODBC statement handle in cursor state. However unlike its
 /// synchronous sibling this statement handle is in asynchronous polling mode.
-pub struct CursorPolling<Stmt: AsStatementRef> {
+pub struct CursorPolling<Stmt: Statement> {
     /// A statement handle in cursor state with asynchronous mode enabled.
     statement: Stmt,
 }
 
 impl<S> CursorPolling<S>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     /// Users of this library are encouraged not to call this constructor directly. This method is
     /// pubilc so users with an understanding of the raw ODBC C-API have a way to create an
@@ -57,7 +57,7 @@ where
 
 impl<S> AsStatementRef for CursorPolling<S>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     fn as_stmt_ref(&mut self) -> StatementRef<'_> {
         self.statement.as_stmt_ref()
@@ -66,11 +66,14 @@ where
 
 impl<S> Drop for CursorPolling<S>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     fn drop(&mut self) {
-        let mut stmt = self.statement.as_stmt_ref();
-        if let Err(e) = stmt.close_cursor().into_result(&stmt) {
+        if let Err(e) = self
+            .statement
+            .end_cursor_scope()
+            .into_result(&self.statement)
+        {
             // Avoid panicking, if we already have a panic. We don't want to mask the original
             // error.
             if !panicking() {

--- a/odbc-api/src/execute.rs
+++ b/odbc-api/src/execute.rs
@@ -43,7 +43,7 @@ pub async fn execute_with_parameters_polling<S>(
     sleep: impl Sleep,
 ) -> Result<Option<CursorPolling<S>>, Error>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     unsafe {
         if let Some(statement) = bind_parameters(statement, params)? {
@@ -59,19 +59,19 @@ unsafe fn bind_parameters<S>(
     mut params: impl ParameterCollectionRef,
 ) -> Result<Option<S>, Error>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     unsafe {
         let parameter_set_size = params.parameter_set_size();
 
-        let mut stmt = statement.as_stmt_ref();
         // Reset parameters so we do not dereference stale once by mistake if we call
         // `exec_direct`.
-        stmt.reset_parameters().into_result(&stmt)?;
-        stmt.set_paramset_size(parameter_set_size)
-            .into_result(&stmt)?;
+        statement.reset_parameters().into_result(&statement)?;
+        statement
+            .set_paramset_size(parameter_set_size)
+            .into_result(&statement)?;
         // Bind new parameters passed by caller.
-        params.bind_parameters_to(&mut stmt)?;
+        params.bind_parameters_to(&mut statement)?;
         Ok(Some(statement))
     }
 }
@@ -139,16 +139,15 @@ pub async unsafe fn execute_polling<S>(
     mut sleep: impl Sleep,
 ) -> Result<Option<CursorPolling<S>>, Error>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     unsafe {
-        let mut stmt = statement.as_stmt_ref();
         let result = if let Some(sql) = query {
             // We execute an unprepared "one shot query"
-            wait_for(|| stmt.exec_direct(sql), &mut sleep).await
+            wait_for(|| statement.exec_direct(sql), &mut sleep).await
         } else {
             // We execute a prepared query
-            wait_for(|| stmt.execute(), &mut sleep).await
+            wait_for(|| statement.execute(), &mut sleep).await
         };
 
         // If delayed parameters (e.g. input streams) are bound we might need to put data in order
@@ -157,8 +156,9 @@ where
             .on_success(|| false)
             .on_no_data(|| false)
             .on_need_data(|| true)
-            .into_result(&stmt)?;
+            .into_result(&statement)?;
 
+        let mut stmt = statement.as_stmt_ref();
         if need_data {
             // Check if any delayed parameters have been bound which stream data to the database at
             // statement execution time. Loops over each bound stream.
@@ -172,9 +172,9 @@ where
         }
 
         // Check if a result set has been created.
-        let num_result_cols = wait_for(|| stmt.num_result_cols(), &mut sleep)
+        let num_result_cols = wait_for(|| statement.num_result_cols(), &mut sleep)
             .await
-            .into_result(&stmt)?;
+            .into_result(&statement)?;
         if num_result_cols == 0 {
             Ok(None)
         } else {

--- a/odbc-api/src/execute.rs
+++ b/odbc-api/src/execute.rs
@@ -24,7 +24,7 @@ pub fn execute_with_parameters<S>(
     params: impl ParameterCollectionRef,
 ) -> Result<Option<CursorImpl<S>>, Error>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     unsafe {
         if let Some(statement) = bind_parameters(statement, params)? {
@@ -86,16 +86,15 @@ pub unsafe fn execute<S>(
     query: Option<&SqlText<'_>>,
 ) -> Result<Option<CursorImpl<S>>, Error>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     unsafe {
-        let mut stmt = statement.as_stmt_ref();
         let result = if let Some(sql) = query {
             // We execute an unprepared "one shot query"
-            stmt.exec_direct(sql)
+            statement.exec_direct(sql)
         } else {
             // We execute a prepared query
-            stmt.execute()
+            statement.execute()
         };
 
         // If delayed parameters (e.g. input streams) are bound we might need to put data in order
@@ -104,8 +103,9 @@ where
             .on_success(|| false)
             .on_no_data(|| false)
             .on_need_data(|| true)
-            .into_result(&stmt)?;
+            .into_result(&statement)?;
 
+        let mut stmt = statement.as_stmt_ref();
         if need_data {
             // Check if any delayed parameters have been bound which stream data to the database at
             // statement execution time. Loops over each bound stream.
@@ -118,7 +118,7 @@ where
         }
 
         // Check if a result set has been created.
-        if stmt.num_result_cols().into_result(&stmt)? == 0 {
+        if statement.num_result_cols().into_result(&statement)? == 0 {
             Ok(None)
         } else {
             // Safe: `statement` is in cursor state.

--- a/odbc-api/src/handles/statement.rs
+++ b/odbc-api/src/handles/statement.rs
@@ -141,6 +141,10 @@ impl Statement for StatementRef<'_> {
     fn as_sys(&self) -> HStmt {
         self.handle
     }
+
+    fn end_cursor_scope(&mut self) -> SqlResult<()> {
+        self.close_cursor()
+    }
 }
 
 unsafe impl AnyHandle for StatementRef<'_> {
@@ -190,6 +194,15 @@ where
 pub trait Statement: AnyHandle {
     /// Gain access to the underlying statement handle without transferring ownership to it.
     fn as_sys(&self) -> HStmt;
+
+    /// Invoke [`self::close_cursor`] to close the cursor for implementations which borrow the
+    /// statement handle. For implementations which own the statement handle exclusively, this is a
+    /// no-op. The idea is that if the statement handle is borrowed, we must assume it is going to
+    /// be reused for other queries, so we must spend the effort to close the cursor. If the
+    /// statement handle is exclusively owned it is dropped and freed right away if dropping a
+    /// cursor wrapper. So we do not need to bother with closing the cursor explicitly. The driver
+    /// can take care of it during cleanup however it seems fit.
+    fn end_cursor_scope(&mut self) -> SqlResult<()>;
 
     /// Binds application data buffers to columns in the result set.
     ///
@@ -1183,6 +1196,11 @@ impl Statement for StatementImpl<'_> {
     /// Gain access to the underlying statement handle without transferring ownership to it.
     fn as_sys(&self) -> HStmt {
         self.handle
+    }
+
+    fn end_cursor_scope(&mut self) -> SqlResult<()> {
+        // No-op. We own the statement handle exclusively. We can assume it is freed right after.
+        SqlResult::Success(())
     }
 }
 

--- a/odbc-api/src/handles/statement.rs
+++ b/odbc-api/src/handles/statement.rs
@@ -176,12 +176,6 @@ impl AsStatementRef for StatementImpl<'_> {
     }
 }
 
-impl AsStatementRef for &mut StatementImpl<'_> {
-    fn as_stmt_ref(&mut self) -> StatementRef<'_> {
-        (*self).as_stmt_ref()
-    }
-}
-
 impl AsStatementRef for StatementRef<'_> {
     fn as_stmt_ref(&mut self) -> StatementRef<'_> {
         unsafe { StatementRef::new(self.handle) }

--- a/odbc-api/src/handles/statement.rs
+++ b/odbc-api/src/handles/statement.rs
@@ -170,15 +170,12 @@ pub trait AsStatementRef {
     fn as_stmt_ref(&mut self) -> StatementRef<'_>;
 }
 
-impl AsStatementRef for StatementImpl<'_> {
+impl<T> AsStatementRef for T
+where
+    T: Statement,
+{
     fn as_stmt_ref(&mut self) -> StatementRef<'_> {
-        self.as_stmt_ref()
-    }
-}
-
-impl AsStatementRef for StatementRef<'_> {
-    fn as_stmt_ref(&mut self) -> StatementRef<'_> {
-        unsafe { StatementRef::new(self.handle) }
+        unsafe { StatementRef::new(self.as_sys()) }
     }
 }
 

--- a/odbc-api/src/handles/statement_connection.rs
+++ b/odbc-api/src/handles/statement_connection.rs
@@ -1,6 +1,6 @@
 use odbc_sys::{HStmt, Handle, HandleType};
 
-use crate::handles::{AnyHandle, AsStatementRef, Statement, StatementRef, drop_handle};
+use crate::handles::{AnyHandle, Statement, StatementRef, drop_handle};
 
 /// Statement handle which also takes ownership of Connection
 #[derive(Debug)]
@@ -76,14 +76,5 @@ where
 {
     fn as_sys(&self) -> HStmt {
         self.handle
-    }
-}
-
-impl<C> AsStatementRef for StatementConnection<C>
-where
-    C: StatementParent,
-{
-    fn as_stmt_ref(&mut self) -> StatementRef<'_> {
-        self.as_stmt_ref()
     }
 }

--- a/odbc-api/src/handles/statement_connection.rs
+++ b/odbc-api/src/handles/statement_connection.rs
@@ -1,6 +1,6 @@
 use odbc_sys::{HStmt, Handle, HandleType};
 
-use crate::handles::{AnyHandle, Statement, StatementRef, drop_handle};
+use crate::handles::{AnyHandle, SqlResult, Statement, StatementRef, drop_handle};
 
 /// Statement handle which also takes ownership of Connection
 #[derive(Debug)]
@@ -76,5 +76,9 @@ where
 {
     fn as_sys(&self) -> HStmt {
         self.handle
+    }
+
+    fn end_cursor_scope(&mut self) -> SqlResult<()> {
+        SqlResult::Success(())
     }
 }

--- a/odbc-api/src/preallocated.rs
+++ b/odbc-api/src/preallocated.rs
@@ -42,7 +42,7 @@ pub struct Preallocated<S> {
 
 impl<S> Preallocated<S>
 where
-    S: AsStatementRef,
+    S: Statement,
 {
     /// Users which intend to write their application in safe Rust should prefer using
     /// [`crate::Connection::preallocate`] as opposed to this constructor.
@@ -516,15 +516,17 @@ where
     /// }
     /// ```
     pub fn row_count(&mut self) -> Result<Option<usize>, Error> {
-        let mut stmt = self.statement.as_stmt_ref();
-        stmt.row_count().into_result(&stmt).map(|count| {
-            // ODBC returns -1 in case a row count is not available
-            if count == -1 {
-                None
-            } else {
-                Some(count.try_into().unwrap())
-            }
-        })
+        self.statement
+            .row_count()
+            .into_result(&self.statement)
+            .map(|count| {
+                // ODBC returns -1 in case a row count is not available
+                if count == -1 {
+                    None
+                } else {
+                    Some(count.try_into().unwrap())
+                }
+            })
     }
 
     /// Use this to limit the time the query is allowed to take, before responding with data to the
@@ -538,10 +540,9 @@ where
     /// See:
     /// <https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlsetstmtattr-function>
     pub fn set_query_timeout_sec(&mut self, timeout_sec: usize) -> Result<(), Error> {
-        let mut stmt = self.statement.as_stmt_ref();
-        stmt.as_stmt_ref()
+        self.statement
             .set_query_timeout_sec(timeout_sec)
-            .into_result(&stmt)
+            .into_result(&self.statement)
     }
 
     /// The number of seconds to wait for a SQL statement to execute before returning to the
@@ -552,8 +553,9 @@ where
     /// See:
     /// <https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlsetstmtattr-function>
     pub fn query_timeout_sec(&mut self) -> Result<usize, Error> {
-        let mut stmt = self.statement.as_stmt_ref();
-        stmt.query_timeout_sec().into_result(&stmt)
+        self.statement
+            .query_timeout_sec()
+            .into_result(&self.statement)
     }
 
     /// Call this method to enable asynchronous polling mode on the statement.
@@ -562,8 +564,9 @@ where
     /// [Asynchronous execution using polling
     /// mode](crate::guide#asynchronous-execution-using-polling-mode)
     pub fn into_polling(mut self) -> Result<PreallocatedPolling<S>, Error> {
-        let mut stmt = self.statement.as_stmt_ref();
-        stmt.set_async_enable(true).into_result(&stmt)?;
+        self.statement
+            .set_async_enable(true)
+            .into_result(&self.statement)?;
         Ok(PreallocatedPolling::new(self.statement))
     }
 }

--- a/odbc-api/tests/integration/main.rs
+++ b/odbc-api/tests/integration/main.rs
@@ -4863,34 +4863,7 @@ async fn async_stream_of_rows_from_other_thread(profile: &Profile) {
     assert_eq!([(42i32,)].as_slice(), rows)
 }
 
-#[test_case(MSSQL; "Microsoft SQL Server")]
-#[test_case(MARIADB; "Maria DB")]
-#[test_case(SQLITE_3; "SQLite 3")]
-#[test_case(POSTGRES; "PostgreSQL")]
-fn close_cursor_explicitly(profile: &Profile) {
-    let table_name = table_name!();
-    let (conn, table) = Given::new(&table_name)
-        .column_types(&["INTEGER"])
-        .build(profile)
-        .unwrap();
-    conn.execute(
-        &format!("INSERT INTO {table_name} (a) VALUES (42)"),
-        (),
-        None,
-    )
-    .unwrap();
-    let sql = table.sql_all_ordered_by_id();
-
-    let cursor = conn.execute(&sql, (), None).unwrap().unwrap();
-
-    // Explicitly close the cursor, rather than relying on drop.
-    let result = cursor.close();
-
-    assert!(result.is_ok())
-}
-
 // Learning tests ----------------------------------------------------------------------------------
-
 #[test_case(MSSQL; "Microsoft SQL Server")]
 #[test_case(MARIADB; "Maria DB")]
 // #[test_case(SQLITE_3; "SQLite 3")] SQLite just returns a zeroed out numeric struct


### PR DESCRIPTION
- **feat!: Remove superfluous implementation of AsStatementRef for &mut StatementImpl**
- **feat!: Removed `Cursor::close` because it could violate invariants of statements if it failed for cursors which did not own the statement.**
- **refactor: Use blanket implemenation of AsStatementRef for Statement's rather than individual implementations**
- **refactor!: Cursor and Preallocated statement type now has to implement `Statement` insteaf of `AsStatementRef`.**
- **feat: If it is clear at compile time that a statement handle would be freed right after being closed, it is no longer explicitly closed.**
