### PR TITLE
feat!: Extracted trait `ColumnBufferView` from trait `ColumnBuffer`

### DIFF
--- a/odbc-api/src/buffers/any_buffer.rs
+++ b/odbc-api/src/buffers/any_buffer.rs
@@ -4,7 +4,7 @@ use odbc_sys::{CDataType, Date, Numeric, Time, Timestamp};
 
 use crate::{
     Bit, Error,
-    buffers::columnar::Resize,
+    buffers::columnar::{ColumnBufferView, Resize},
     columnar_bulk_inserter::BoundInputSlice,
     error::TooLargeBufferSize,
     handles::{CData, CDataMut, StatementRef},
@@ -535,8 +535,6 @@ impl<'a> AnySliceMut<'a> {
 }
 
 unsafe impl ColumnBuffer for AnyBuffer {
-    type View<'a> = AnySlice<'a>;
-
     fn capacity(&self) -> usize {
         match self {
             AnyBuffer::Binary(col) => col.capacity(),
@@ -568,6 +566,19 @@ unsafe impl ColumnBuffer for AnyBuffer {
         }
     }
 
+    fn has_truncated_values(&self, num_rows: usize) -> Option<Indicator> {
+        match self {
+            AnyBuffer::Binary(col) => col.has_truncated_values(num_rows),
+            AnyBuffer::Text(col) => col.has_truncated_values(num_rows),
+            AnyBuffer::WText(col) => col.has_truncated_values(num_rows),
+            _ => None,
+        }
+    }
+}
+
+unsafe impl ColumnBufferView for AnyBuffer {
+    type View<'a> = AnySlice<'a>;
+
     fn view(&self, valid_rows: usize) -> AnySlice<'_> {
         match self {
             AnyBuffer::Binary(col) => AnySlice::Binary(col.view(valid_rows)),
@@ -598,15 +609,6 @@ unsafe impl ColumnBuffer for AnyBuffer {
             AnyBuffer::NullableBit(col) => AnySlice::NullableBit(col.iter(valid_rows)),
         }
     }
-
-    fn has_truncated_values(&self, num_rows: usize) -> Option<Indicator> {
-        match self {
-            AnyBuffer::Binary(col) => col.has_truncated_values(num_rows),
-            AnyBuffer::Text(col) => col.has_truncated_values(num_rows),
-            AnyBuffer::WText(col) => col.has_truncated_values(num_rows),
-            _ => None,
-        }
-    }
 }
 
 impl Resize for AnyBuffer {
@@ -617,7 +619,9 @@ impl Resize for AnyBuffer {
 
 #[cfg(test)]
 mod tests {
-    use crate::buffers::{AnySlice, AnySliceMut, ColumnBuffer, Resize};
+    use crate::buffers::{
+        AnySlice, AnySliceMut, ColumnBuffer as _, Resize, columnar::ColumnBufferView as _,
+    };
 
     use super::AnyBuffer;
 

--- a/odbc-api/src/buffers/columnar.rs
+++ b/odbc-api/src/buffers/columnar.rs
@@ -66,7 +66,9 @@ impl<C: ColumnBuffer> ColumnarBuffer<C> {
     pub fn num_cols(&self) -> usize {
         self.columns.len()
     }
+}
 
+impl<C: ColumnBufferView> ColumnarBuffer<C> {
     /// Use this method to gain read access to the actual column data.
     ///
     /// # Parameters
@@ -237,12 +239,17 @@ pub struct ColumnarBuffer<C> {
     columns: Vec<(u16, C)>,
 }
 
-/// A buffer for a single column intended to be used together with [`ColumnarBuffer`].
+/// Access a safe view of the column buffer.
+///
+/// After a fetch operation buffers may only partially be filled with data, the rest of the buffer
+/// may contain uninitialized values. Also we must not permit any operation which would invalidate
+/// the addresses of the buffer. To make reading buffer contents after a fetch safe,
+/// [`ColumnBuffer`]s implement this trait to offer safe views.
 ///
 /// # Safety
 ///
 /// Views must not allow access to uninitialized / invalid rows.
-pub unsafe trait ColumnBuffer: CDataMut {
+pub unsafe trait ColumnBufferView {
     /// Immutable view on the column data. Used in safe abstractions. User must not be able to
     /// access uninitialized or invalid memory of the buffer through this interface.
     type View<'a>
@@ -254,10 +261,19 @@ pub unsafe trait ColumnBuffer: CDataMut {
     /// not guarantee the accessed element to be valid and in a defined state. It also can not panic
     /// on accessing an undefined element.
     fn view(&self, valid_rows: usize) -> Self::View<'_>;
+}
 
-    // /// Fills the column with the default representation of values, between `from` and `to` index.
-    // fn fill_default(&mut self, from: usize, to: usize);
-
+/// A buffer for a single column intended to be used together with [`ColumnarBuffer`].
+///
+/// # Safety
+///
+/// Implementations must ensure that:
+///
+/// * Capacity must be correctly reported otherwise data may be written outside its bounds.
+/// * truncation must be correctly reported. Code which reuses the same column buffer for reading
+///   and inserting may rely on this in order to avoid passing values indicators of truncated values
+///   in bulk insertions. This could lead to out of bounds memory access.
+pub unsafe trait ColumnBuffer: CDataMut {
     /// Current capacity of the column
     fn capacity(&self) -> usize;
 
@@ -269,9 +285,9 @@ pub unsafe trait ColumnBuffer: CDataMut {
     fn has_truncated_values(&self, num_rows: usize) -> Option<Indicator>;
 }
 
-unsafe impl<T> ColumnBuffer for WithDataType<T>
+unsafe impl<T> ColumnBufferView for WithDataType<T>
 where
-    T: ColumnBuffer,
+    T: ColumnBufferView,
 {
     type View<'a>
         = T::View<'a>
@@ -281,7 +297,12 @@ where
     fn view(&self, valid_rows: usize) -> T::View<'_> {
         self.value.view(valid_rows)
     }
+}
 
+unsafe impl<T> ColumnBuffer for WithDataType<T>
+where
+    T: ColumnBuffer,
+{
     fn capacity(&self) -> usize {
         self.value.capacity()
     }
@@ -522,18 +543,23 @@ unsafe impl<T> ColumnBuffer for Vec<T>
 where
     T: Pod,
 {
-    type View<'a> = &'a [T];
-
-    fn view(&self, valid_rows: usize) -> &[T] {
-        &self[..valid_rows]
-    }
-
     fn capacity(&self) -> usize {
         self.len()
     }
 
     fn has_truncated_values(&self, _num_rows: usize) -> Option<Indicator> {
         None
+    }
+}
+
+unsafe impl<T> ColumnBufferView for Vec<T>
+where
+    T: Pod,
+{
+    type View<'a> = &'a [T];
+
+    fn view(&self, valid_rows: usize) -> &[T] {
+        &self[..valid_rows]
     }
 }
 

--- a/odbc-api/src/buffers/text_column.rs
+++ b/odbc-api/src/buffers/text_column.rs
@@ -1,6 +1,6 @@
 use crate::{
     DataType, Error,
-    buffers::Resize,
+    buffers::{Resize, columnar::ColumnBufferView},
     columnar_bulk_inserter::BoundInputSlice,
     error::TooLargeBufferSize,
     handles::{
@@ -325,19 +325,10 @@ impl WCharColumn {
     }
 }
 
-unsafe impl<C: 'static> ColumnBuffer for TextColumn<C>
+unsafe impl<C> ColumnBuffer for TextColumn<C>
 where
     TextColumn<C>: CDataMut + HasDataType,
 {
-    type View<'a> = TextColumnView<'a, C>;
-
-    fn view(&self, valid_rows: usize) -> TextColumnView<'_, C> {
-        TextColumnView {
-            num_rows: valid_rows,
-            col: self,
-        }
-    }
-
     /// Maximum number of text strings this column may hold.
     fn capacity(&self) -> usize {
         self.indicators.len()
@@ -353,6 +344,17 @@ where
                 let indicator = Indicator::from_isize(indicator);
                 indicator.is_truncated(max_bin_length).then_some(indicator)
             })
+    }
+}
+
+unsafe impl<C: 'static> ColumnBufferView for TextColumn<C> {
+    type View<'a> = TextColumnView<'a, C>;
+
+    fn view(&self, valid_rows: usize) -> TextColumnView<'_, C> {
+        TextColumnView {
+            num_rows: valid_rows,
+            col: self,
+        }
     }
 }
 


### PR DESCRIPTION
This has been done in order to allow `ColumnBuffer` to be Object safe
and support `ColumnarBuffer`s of &dyn ColumnBuffer's
