### PR TITLE
Not set paramset size when size is 1

### DIFF
--- a/odbc-api/src/execute.rs
+++ b/odbc-api/src/execute.rs
@@ -67,9 +67,12 @@ where
         // Reset parameters so we do not dereference stale once by mistake if we call
         // `exec_direct`.
         statement.reset_parameters().into_result(&statement)?;
-        statement
-            .set_paramset_size(parameter_set_size)
-            .into_result(&statement)?;
+
+        if parameter_set_size != 1 {
+            statement
+                .set_paramset_size(parameter_set_size)
+                .into_result(&statement)?;
+        }
         // Bind new parameters passed by caller.
         params.bind_parameters_to(&mut statement)?;
         Ok(Some(statement))


### PR DESCRIPTION
I'm using odbc-api and mdbtools driver for my app. The usage is like below
```rust
let mut stmt = conn.prepare(&sql)?;
let cursor_opt = stmt.execute(())?;
```
I encountered an error `Diagnostics { record: State: HY092, Native error: 0, Message: [unixODBC][Driver Manager]Invalid attribute/option identifier, function: \"SQLSetStmtAttr\" }")` .
I'm not familar with odbc, this pr might not be right fix.