### PR TITLE
feat: Make trait implementations for `Box<dyn InputParameter>` generic over lifetime.

### DIFF
--- a/odbc-api/src/handles/bind.rs
+++ b/odbc-api/src/handles/bind.rs
@@ -13,6 +13,8 @@ use crate::DataType;
 /// In case of variable sized types [`Self::indicator_ptr`] must not exceed the value pointed to by
 /// [`Self::value_ptr`]. This requirement is a bit tricky since, if the same indicator buffer is
 /// used in an output paramater the indicator value may be larger in case of truncation.
+///
+/// The values pointed to must be valid for the lifetime of the [`CData`] instance.
 pub unsafe trait CData {
     /// The identifier of the C data type of the value buffer. When it is retrieving data from the
     /// data source with `fetch`, the driver converts the data to this type. When it sends data to

--- a/odbc-api/src/handles/statement.rs
+++ b/odbc-api/src/handles/statement.rs
@@ -221,7 +221,8 @@ pub trait Statement: AnyHandle {
     /// # Safety
     ///
     /// It is the callers responsibility to make sure the bound columns live until they are no
-    /// longer bound.
+    /// longer bound. I.e. `target` must live long enough to cover every read of the bound value
+    /// pointers until they are unbound.
     unsafe fn bind_col(&mut self, column_number: u16, target: &mut impl CDataMut) -> SqlResult<()> {
         unsafe {
             SQLBindCol(

--- a/odbc-api/src/parameter.rs
+++ b/odbc-api/src/parameter.rs
@@ -624,7 +624,7 @@ where
 unsafe impl<T> OutputParameter for WithDataType<T> where T: Pod {}
 
 // Allow for input parameters whose type is only known at runtime.
-unsafe impl CData for Box<dyn InputParameter> {
+unsafe impl CData for Box<dyn InputParameter + '_> {
     fn cdata_type(&self) -> CDataType {
         self.as_ref().cdata_type()
     }
@@ -642,12 +642,13 @@ unsafe impl CData for Box<dyn InputParameter> {
     }
 }
 
-impl HasDataType for Box<dyn InputParameter> {
+impl HasDataType for Box<dyn InputParameter + '_> {
     fn data_type(&self) -> DataType {
         self.as_ref().data_type()
     }
 }
-unsafe impl CElement for Box<dyn InputParameter> {
+
+unsafe impl CElement for Box<dyn InputParameter + '_> {
     fn assert_completness(&self) {
         self.as_ref().assert_completness()
     }

--- a/odbc-api/tests/integration/main.rs
+++ b/odbc-api/tests/integration/main.rs
@@ -2542,6 +2542,34 @@ fn arbitrary_input_parameters(profile: &Profile) {
     assert_eq!("Hello, World!,42", actual)
 }
 
+#[test_case(MSSQL; "Microsoft SQL Server")]
+#[test_case(MARIADB; "Maria DB")]
+#[test_case(SQLITE_3; "SQLite 3")]
+#[test_case(POSTGRES; "PostgreSQL")]
+fn arbitrary_input_parameters_with_borrowed_data(profile: &Profile) {
+    let table_name = table_name!();
+    let (conn, table) = Given::new(&table_name)
+        .column_types(&["VARCHAR(20)", "INT"])
+        .build(profile)
+        .unwrap();
+
+    // Borrowed text parameter
+    let text = "Hello, World!".to_owned();
+    let local_text_ref = text.as_str();
+    let number = 42i32;
+
+    let insert_statement = format!("INSERT INTO {table_name} (a, b) VALUES (?, ?);");
+    let parameters: Vec<Box<dyn InputParameter + '_>> = vec![
+        Box::new(VarCharSlice::new(local_text_ref.as_bytes())),
+        Box::new(number),
+    ];
+    conn.execute(&insert_statement, parameters.as_slice(), None)
+        .unwrap();
+
+    let actual = table.content_as_string(&conn);
+    assert_eq!("Hello, World!,42", actual);
+}
+
 /// Ensures access to driver and data source info is synchronized correctly when multiple threads
 /// attempt to query it at the same time. First, we query the list of the known drivers and data
 /// sources on the main thread. Then we spawn multiple threads that attempt to query these lists in


### PR DESCRIPTION
This allows borrowing data without reallocation then passing input
parameters with heterogenous types only decided at runtime.
